### PR TITLE
Fix membership info navigation route on home screen

### DIFF
--- a/src/components/home/HomeSignedOutPanel.js
+++ b/src/components/home/HomeSignedOutPanel.js
@@ -9,7 +9,7 @@ export default function HomeSignedOutPanel({ navigation }) {
       <View style={{ height: 18 }} />
       <GlowingGlassButton text="Join today" variant="dark" ring onPress={() => navigation.navigate('MembershipStart')} />
       <View style={{ height: 10 }} />
-      <GlowingGlassButton text="Learn about Membership & Profit Sharing" variant="light" onPress={() => navigation.navigate('Membership')} />
+      <GlowingGlassButton text="Learn about Membership & Profit Sharing" variant="light" onPress={() => navigation.navigate('MembershipInfo')} />
     </>
   );
 }

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -142,7 +142,7 @@ export default function HomeScreen({ navigation }) {
               <View style={{ height: 18 }} />
               <GlowingGlassButton text="Join today" variant="dark" ring onPress={() => navigation.navigate('MembershipStart')} />
               <View style={{ height: 10 }} />
-              <GlowingGlassButton text="Learn about Membership & Profit Sharing" variant="light" onPress={() => navigation.navigate('Membership')} />
+              <GlowingGlassButton text="Learn about Membership & Profit Sharing" variant="light" onPress={() => navigation.navigate('MembershipInfo')} />
 
               <Pressable onPress={() => navigation.navigate('Community')} style={{ marginTop: 16 }}>
                 <Text style={styles.sectionLabel}>Community fund (this month)</Text>


### PR DESCRIPTION
## Summary
- Ensure 'Learn about Membership & Profit Sharing' button directs to the correct MembershipInfo screen
- Update home signed-out panel to use MembershipInfo navigation target

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5b038e0dc8322aa35a8c68dabfb7c