### PR TITLE
Show user's pay-it-forward contributions

### DIFF
--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -36,7 +36,7 @@ const [stats, setStats] = useState({ freebiesLeft:0, dividendsPending:0, discoun
 
   const payload = user ? JSON.stringify({ v:1, type:'member', uid:user.id, email:user.email, tier:summary.tier, ts:Date.now() }) : 'ruminate:member';
 
-  useEffect(()=>{ let m=true; const email=(typeof user!=='undefined'&&user&&user.email)?user.email:(summary&&summary.user&&summary.user.email)?summary.user.email:(globalThis&&globalThis.auth&&globalThis.auth.user&&globalThis.auth.user.email)?globalThis.auth.user.email:null; if(!email){return;} getPIFByEmail(email).then(r=>{ if(m) setPifSelfCents(Number(r.total_cents)||0); }).catch(()=>{}); return ()=>{ m=false }; },[user,summary]);
+  useEffect(()=>{ let m=true; const email=(typeof user!=='undefined'&&user&&user.email)?user.email:(summary&&summary.user&&summary.user.email)?summary.user.email:(globalThis&&globalThis.auth&&globalThis.auth.user&&globalThis.auth.user.email)?globalThis.auth.user.email:null; if(!email){ setPifSelfCents(0); return; } getPIFByEmail(email).then(r=>{ if(m) setPifSelfCents(Number(r.total_cents)||0); }).catch(()=>{ if(m) setPifSelfCents(0); }); return ()=>{ m=false }; },[user,summary]);
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
@@ -59,7 +59,7 @@ const [stats, setStats] = useState({ freebiesLeft:0, dividendsPending:0, discoun
             </View>
             <View style={styles.gridRow}>
               <Stat label="Discount uses" value={stats.discountUses} />
-              <Stat label="Pay-it-forward" value={stats.payItForwardContrib} suffix="£" />
+              <Stat label="Pay-it-forward" value={(pifSelfCents/100).toFixed(2)} suffix="£" />
             </View>
             <View style={styles.gridRow}>
               <Stat label="Community fund" value={stats.communityContrib} suffix="£" />


### PR DESCRIPTION
## Summary
- Replace placeholder stats with actual pay-it-forward total from Supabase for signed-in user
- Reset contribution amount when user is signed out or lookup fails

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a5ba99c7cc8322af02ce056b44cd2f