### PR TITLE
Use stable member UUIDs in QR codes and add lookup function

### DIFF
--- a/src/components/membership/MembershipSignedInPanel.js
+++ b/src/components/membership/MembershipSignedInPanel.js
@@ -17,7 +17,8 @@ function Stat({ label, value, prefix='', suffix='' }) {
 
 export default function MembershipSignedInPanel({ summary, stats, user }) {
   const navigation = useNavigation();
-  const payload = user ? JSON.stringify({ v:1, type:'member', uid:user.id, email:user.email, tier:summary.tier, ts:Date.now() }) : 'ruminate:member';
+  // Stable opaque member identifier for QR payload
+  const payload = user ? `ruminate:${user.id}` : 'ruminate:member';
   const isPaid = summary.tier === 'paid';
 
   return (

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -38,7 +38,8 @@ const [stats, setStats] = useState({ freebiesLeft:3, dividendsPending:0, loyalty
   useEffect(() => { refresh(); }, [refresh]);
   useFocusEffect(useCallback(() => { let on = true; (async()=>{ if(on) await refresh(); })(); return () => { on = false; }; }, [refresh]));
 
-  const payload = user ? JSON.stringify({ v:1, type:'member', uid:user.id, email:user.email, tier:summary.tier, ts:Date.now() }) : 'ruminate:member';
+  // Stable opaque member identifier for QR payload
+  const payload = user ? `ruminate:${user.id}` : 'ruminate:member';
 
   useEffect(()=>{ let m=true; const email=(typeof user!=='undefined'&&user&&user.email)?user.email:(summary&&summary.user&&summary.user.email)?summary.user.email:(globalThis&&globalThis.auth&&globalThis.auth.user&&globalThis.auth.user.email)?globalThis.auth.user.email:null; if(!email){ setPifSelfCents(0); return; } getPIFByEmail(email).then(r=>{ if(m) setPifSelfCents(Number(r.total_cents)||0); }).catch(()=>{ if(m) setPifSelfCents(0); }); return ()=>{ m=false }; },[user,summary]);
 

--- a/src/screens/ScanScreen.js
+++ b/src/screens/ScanScreen.js
@@ -1,16 +1,18 @@
 
 import React from 'react';
 import { View, Text, Button } from 'react-native';
+import { supabase } from '../lib/supabase';
 
 async function loadScanner() {
   try { const m = await import('expo-barcode-scanner'); return m.BarCodeScanner; }
   catch { return null; }
 }
 
-export default function ScanScreen(){
-  const [Scanner,setScanner]=React.useState(null);
-  const [status,setStatus]=React.useState(null);
-  const [loading,setLoading]=React.useState(true);
+  export default function ScanScreen(){
+    const [Scanner,setScanner]=React.useState(null);
+    const [status,setStatus]=React.useState(null);
+    const [loading,setLoading]=React.useState(true);
+    const [info,setInfo]=React.useState(null);
 
   React.useEffect(()=>{
     let on=true;
@@ -27,14 +29,31 @@ export default function ScanScreen(){
     return()=>{on=false};
   },[]);
 
-  if(Scanner && status==='granted'){
-    return (
-      <Scanner
-        style={{flex:1}}
-        onBarCodeScanned={({ type, data })=>{ console.log('scanned', type, data); }}
-      />
-    );
-  }
+    if(Scanner && status==='granted'){
+      return (
+        <>
+          <Scanner
+            style={{flex:1}}
+            onBarCodeScanned={async ({ type, data })=>{
+              const prefix='ruminate:';
+              if(!data.startsWith(prefix)) return;
+              const member_uuid=data.slice(prefix.length);
+              try {
+                const { data: res } = await supabase.functions.invoke('member-lookup',{ body:{ member_uuid } });
+                setInfo(res);
+              } catch(err){ console.log('lookup failed', err); }
+            }}
+          />
+          {info && (
+            <View style={{position:'absolute',bottom:20,left:0,right:0,alignItems:'center'}}>
+              <Text style={{backgroundColor:'#fff',padding:8,borderRadius:6}}>
+                {`Tier: ${info.tier||'free'} (${info.status||'none'})`}
+              </Text>
+            </View>
+          )}
+        </>
+      );
+    }
 
   return (
     <View style={{flex:1,alignItems:'center',justifyContent:'center',padding:24}}>

--- a/supabase/functions/member-lookup/index.ts
+++ b/supabase/functions/member-lookup/index.ts
@@ -1,0 +1,40 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SB_URL = Deno.env.get("SB_URL")!;
+const SB_SERVICE_ROLE_KEY = Deno.env.get("SB_SERVICE_ROLE_KEY")!;
+
+function cors() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "authorization,content-type",
+  };
+}
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: cors() });
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: cors() });
+
+  const { member_uuid } = await req.json().catch(() => ({}));
+  if (!member_uuid) {
+    return new Response(JSON.stringify({ error: "member_uuid required" }), {
+      status: 400,
+      headers: { ...cors(), "content-type": "application/json" },
+    });
+  }
+
+  const admin = createClient(SB_URL, SB_SERVICE_ROLE_KEY);
+  const { data: profile } = await admin.from("profiles").select("tier").eq("user_id", member_uuid).maybeSingle();
+  const { data: membership } = await admin.from("memberships").select("status,next_billing_at").eq("user_id", member_uuid).maybeSingle();
+
+  return new Response(
+    JSON.stringify({
+      member_uuid,
+      tier: profile?.tier ?? "free",
+      status: membership?.status ?? "none",
+      next_billing_at: membership?.next_billing_at ?? null,
+    }),
+    { headers: { ...cors(), "content-type": "application/json" } }
+  );
+});


### PR DESCRIPTION
## Summary
- Generate membership QR codes using stable `ruminate:<uuid>` payloads
- Scan screen verifies member UUID with new `member-lookup` edge function and displays tier/status
- Add `member-lookup` Supabase Edge Function to return membership details for a given UUID

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5d3ee64608322a596c195a401a6df