### PR TITLE
Add Instagram widget with latest post

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -9,7 +9,7 @@ import GlowingGlassButton from '../components/GlowingGlassButton';
 import { supabase } from '../lib/supabase';
 import { getMembershipSummary } from '../services/membership';
 import { getFundCurrent, getFundProgress } from '../services/community';
-import { getToday, getPayItForward, getFreeDrinkProgress, openInstagramProfile, getWeeklyHours } from '../services/homeData';
+import { getToday, getPayItForward, getFreeDrinkProgress, openInstagramProfile, getWeeklyHours, getLatestInstagramPost } from '../services/homeData';
 import { getMyStats } from '../services/stats';
 import { getCMS } from '../services/cms';
 
@@ -44,6 +44,7 @@ export default function HomeScreen({ navigation }) {
   const [loyalty, setLoyalty] = useState({ current: 0, target: 8 });
   const [freebiesLeft, setFreebiesLeft] = useState(0);
   const [rumiQuote, setRumiQuote] = useState(null);
+  const [igPost, setIgPost] = useState({ image: null, caption: '' });
 
   // Load data whenever screen focuses
   useEffect(() => {
@@ -63,6 +64,7 @@ let mounted = true;
       try { const s = await getPIFStats(); if (mounted) setPif(s); } catch {}
       try { const d = await getFreeDrinkProgress(); if (mounted) setLoyalty(d); } catch {}
       try { const stats = await getMyStats(); if (mounted) setFreebiesLeft(stats.freebiesLeft || 0); } catch {}
+      try { const ig = await getLatestInstagramPost(); if (mounted) setIgPost(ig); } catch {}
 
       try {
         const cms = await getCMS();
@@ -223,8 +225,16 @@ let mounted = true;
 
         <View style={styles.card}>
           <Text style={styles.cardTitle}>Latest on Instagram</Text>
-          <Pressable onPress={openInstagramProfile} style={styles.igCard}>
-            <Image source={{ uri: 'https://picsum.photos/seed/ruminatecafe/1200/700' }} style={styles.igImage} resizeMode="cover" />
+          {igPost?.image ? (
+            <View style={styles.igPolaroid}>
+              <Image source={{ uri: igPost.image }} style={styles.igImage} resizeMode="cover" />
+              {igPost?.caption ? <Text style={styles.igCaption}>{igPost.caption}</Text> : null}
+            </View>
+          ) : (
+            <Text style={styles.muted}>Unable to load Instagram.</Text>
+          )}
+          <Pressable onPress={openInstagramProfile} style={styles.igButton}>
+            <Text style={styles.igButtonText}>View on Instagram</Text>
           </Pressable>
         </View>
 
@@ -283,8 +293,24 @@ container: { flex: 1, backgroundColor: palette.cream },
 
   pifBig: { textAlign: 'center',  fontSize: 40, lineHeight: 40, color: palette.clay, fontFamily: 'Fraunces_700Bold' },
 
-  igCard: { borderRadius: 12, overflow: 'hidden', borderWidth: 1, borderColor: palette.border },
-  igImage: { width: '100%', height: 180 },
+  igPolaroid: {
+    backgroundColor: '#fff',
+    padding: 12,
+    borderRadius: 12,
+    borderColor: palette.border,
+    borderWidth: 1,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    transform: [{ rotate: '-2deg' }],
+    marginBottom: 12,
+  },
+  igImage: { width: '100%', height: 180, borderRadius: 4 },
+  igCaption: { marginTop: 8, color: palette.coffee, fontFamily: 'Fraunces_600SemiBold', textAlign: 'center' },
+  igButton: { alignSelf: 'center', backgroundColor: palette.coffee, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 6 },
+  igButtonText: { color: palette.cream, fontFamily: 'Fraunces_600SemiBold', fontSize: 14 },
 
   rumiQuoteStandalone: {
     fontSize: 18,

--- a/src/services/homeData.js
+++ b/src/services/homeData.js
@@ -16,3 +16,16 @@ export async function getPayItForward(){ return { available:7, contributed:124 }
 export async function getFreeDrinkProgress(){ return { current:3, target:8 }; }
 
 export async function openInstagramProfile(){ const app='instagram://user?username=ruminatecafe'; const web='https://www.instagram.com/ruminatecafe/'; try{ const can=await Linking.canOpenURL(app); await Linking.openURL(can?app:web); } catch { Linking.openURL(web); } }
+
+export async function getLatestInstagramPost(){
+  try{
+    const res=await fetch('https://www.instagram.com/ruminatecafe/?__a=1&__d=dis');
+    const json=await res.json();
+    const node=json?.graphql?.user?.edge_owner_to_timeline_media?.edges?.[0]?.node;
+    const image=node?.display_url||null;
+    const caption=node?.edge_media_to_caption?.edges?.[0]?.node?.text||'';
+    return { image, caption };
+  }catch{
+    return { image:null, caption:'' };
+  }
+}


### PR DESCRIPTION
## Summary
- fetch latest ruminatecafe Instagram post via public endpoint
- display latest Instagram photo and caption in polaroid style on home screen
- include button to open profile on Instagram

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5e04bf3308322bfa9cee650879b42