### PR TITLE
feat: add subscription management screen

### DIFF
--- a/src/navigation/Router.js
+++ b/src/navigation/Router.js
@@ -7,6 +7,7 @@ import SwipeTabs from './SwipeTabs';
 import MembershipInfoScreen from '../screens/MembershipInfoScreen';
 import MembershipStartScreen from '../screens/MembershipStartScreen';
 import LoyaltyCardCreateScreen from '../screens/LoyaltyCardCreateScreen';
+import ManageSubscriptionScreen from '../screens/ManageSubscriptionScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -19,6 +20,7 @@ export default function Router() {
         <Stack.Screen name="MainTabs" component={SwipeTabs} />
         <Stack.Screen name="MembershipInfo" component={MembershipInfoScreen} />
         <Stack.Screen name="MembershipStart" component={MembershipStartScreen} />
+        <Stack.Screen name="ManageSubscription" component={ManageSubscriptionScreen} />
         <Stack.Screen name="LoyaltyCardCreate" component={LoyaltyCardCreateScreen} />
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/screens/AdminScreen.js
+++ b/src/screens/AdminScreen.js
@@ -26,6 +26,10 @@ export default function AdminScreen({ navigation }){
         <Text style={styles.p}>Moderate activity and manage the café workflow.</Text>
 
         <View style={{ marginTop:20 }}>
+          <GlowingGlassButton text="Manage subscription" variant="light" onPress={() => navigation.navigate('ManageSubscription')} />
+        </View>
+
+        <View style={{ marginTop:12 }}>
           <GlowingGlassButton text="Sign out" variant="light" onPress={async()=>{
             try { await signOut(); } catch {}
             try { navigation.reset({ index:0, routes:[{ name:'Home' }] }); } catch {}

--- a/src/screens/ManageSubscriptionScreen.js
+++ b/src/screens/ManageSubscriptionScreen.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { View, Text, StyleSheet, Alert, Linking } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import GlowingGlassButton from '../components/GlowingGlassButton';
+import { palette } from '../design/theme';
+
+export default function ManageSubscriptionScreen({ navigation }) {
+  const handleUpgrade = () => {
+    try { navigation.navigate('MembershipStart'); } catch {}
+  };
+  const handleCancel = async () => {
+    try {
+      await Linking.openURL('https://apps.apple.com/account/subscriptions');
+    } catch {
+      Alert.alert('Unable to open settings', 'Please manage your subscription in the iOS Settings app.');
+    }
+  };
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Manage Subscription</Text>
+        <Text style={styles.p}>Upgrade to a paid membership or cancel your subscription.</Text>
+        <View style={{ marginTop:20 }}>
+          <GlowingGlassButton text="Upgrade to paid membership" variant="dark" onPress={handleUpgrade} />
+        </View>
+        <View style={{ marginTop:12 }}>
+          <GlowingGlassButton text="Cancel subscription" variant="light" onPress={handleCancel} />
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex:1, backgroundColor: palette.cream },
+  content: { flex:1, padding:20 },
+  title: { fontFamily:'Fraunces_700Bold', fontSize:22, color:palette.coffee, marginBottom:8 },
+  p: { color:palette.coffee, fontSize:16 }
+});


### PR DESCRIPTION
## Summary
- add Manage Subscription admin flow
- allow users to upgrade or cancel membership

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5e35e3b288322b8189f62b4364a3b