### PR TITLE
Replace receipts with community progress

### DIFF
--- a/src/navigation/Router.js
+++ b/src/navigation/Router.js
@@ -1,6 +1,5 @@
 
 import React from 'react';
-import CommunityScreen from '../screens/CommunityScreen';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import SwipeTabs from './SwipeTabs';
@@ -14,8 +13,6 @@ export default function Router() {
   return (
     <NavigationContainer>
       <Stack.Navigator initialRouteName="MainTabs" screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="Community" component={CommunityScreen} options={{ headerShown:false }} />
-
         <Stack.Screen name="MainTabs" component={SwipeTabs} />
         <Stack.Screen name="MembershipInfo" component={MembershipInfoScreen} />
         <Stack.Screen name="MembershipStart" component={MembershipStartScreen} />

--- a/src/navigation/SwipeTabs.js
+++ b/src/navigation/SwipeTabs.js
@@ -9,7 +9,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import HomeScreen from '../screens/HomeScreen';
 import MenuScreen from '../screens/MenuScreen';
 import MembershipScreen from '../screens/MembershipScreen';
-import ReceiptScreen from '../screens/ReceiptScreen';
+import CommunityScreen from '../screens/CommunityScreen';
 import AdminScreen from '../screens/AdminScreen';
 
 const Tab = createMaterialTopTabNavigator();
@@ -69,9 +69,9 @@ export default function SwipeTabs() {
         options={{ title: 'You', tabBarIcon: ({ color }) => <Ionicons name="qr-code-outline" size={22} color={color} /> }}
       />
       <Tab.Screen
-        name="Receipts"
-        component={ReceiptScreen}
-        options={{ title: 'Receipts', tabBarIcon: ({ color }) => <Ionicons name="receipt-outline" size={22} color={color} /> }}
+        name="Community"
+        component={CommunityScreen}
+        options={{ title: 'Community', tabBarIcon: ({ color }) => <Ionicons name="people-outline" size={22} color={color} /> }}
       />
       <Tab.Screen
         name="Admin"

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -39,7 +39,6 @@ export default function HomeScreen({ navigation }) {
   const [member, setMember] = useState({ status: 'none', next_billing_at: null, signedIn: false });
   const [fund, setFund] = useState({ total_cents: 0, goal_cents: 0 });
   const [today, setToday] = useState({ openNow: false, until: '--:--', specials: [] });
-  const communityProgress=Math.max(0,Math.min(1,fund?.progress||0));
   const [pif, setPif] = useState({ available: 0, contributed: 0 });
   const [loyalty, setLoyalty] = useState({ current: 0, target: 8 });
   const [freebiesLeft, setFreebiesLeft] = useState(0);
@@ -122,7 +121,7 @@ let mounted = true;
         <View style={styles.hero}>
           <Text style={styles.title}>Welcome to Ruminate Café</Text>
           <Text style={styles.subcopy}>
-            Track perks, collect stamps, view receipts, and support the community fund.
+            Track perks, collect stamps, and support the community fund.
           </Text>
 
           <View style={{ height: 18 }} />
@@ -136,16 +135,7 @@ let mounted = true;
 
           {signedIn ? (
             <View>
-              <Pressable onPress={() => navigation.navigate('Community')} style={{ marginTop: 16 }}>
-                <Text style={styles.sectionLabel}>Community fund (this month)</Text>
-                <ProgressBar value={fund?.total_cents || 0} max={(fund?.goal_cents || 0) || 1} />
-                <Text style={styles.muted}>
-                  £{((fund?.total_cents || 0) / 100).toFixed(2)}
-                  {(fund?.goal_cents || 0) ? ` / £${((fund?.goal_cents || 0) / 100).toFixed(2)}` : ''}
-                </Text>
-              </Pressable>
-
-              <View style={{ marginTop: 20 }}>
+              <View style={{ marginTop: 16 }}>
                 <Text style={styles.sectionLabel}>Loyalty stamps progress</Text>
                 <ProgressBar value={loyalty.current} max={loyalty.target} tint={palette.coffee} track="#F1E3D3" />
                 <Text style={styles.muted}>{loyalty.current} / {loyalty.target} stamps</Text>
@@ -172,15 +162,6 @@ let mounted = true;
               <GlowingGlassButton text="Join today" variant="dark" ring onPress={() => navigation.navigate('MembershipStart')} />
               <View style={{ height: 10 }} />
               <GlowingGlassButton text="Learn about Membership & Profit Sharing" variant="light" onPress={() => navigation.navigate('MembershipInfo')} />
-
-              <Pressable onPress={() => navigation.navigate('Community')} style={{ marginTop: 16 }}>
-                <Text style={styles.sectionLabel}>Community fund (this month)</Text>
-                <ProgressBar value={fund?.total_cents || 0} max={(fund?.goal_cents || 0) || 1} />
-                <Text style={styles.muted}>
-                  £{((fund?.total_cents || 0) / 100).toFixed(2)}
-                  {(fund?.goal_cents || 0) ? ` / £${((fund?.goal_cents || 0) / 100).toFixed(2)}` : ''}
-                </Text>
-              </Pressable>
             </View>
           )}
         </View>
@@ -239,9 +220,13 @@ let mounted = true;
         </View>
 
         <View style={styles.card}>
-          <Text style={styles.cardTitle}>Recent receipts</Text>
-          <Pressable onPress={() => navigation.navigate('Receipt')}>
-            <Text style={styles.link}>View all receipts →</Text>
+          <Pressable onPress={() => navigation.navigate('Community')}>
+            <Text style={styles.cardTitle}>Community fund (this month)</Text>
+            <ProgressBar value={fund?.total_cents || 0} max={(fund?.goal_cents || 0) || 1} />
+            <Text style={styles.muted}>
+              £{((fund?.total_cents || 0) / 100).toFixed(2)}
+              {(fund?.goal_cents || 0) ? ` / £${((fund?.goal_cents || 0) / 100).toFixed(2)}` : ''}
+            </Text>
           </Pressable>
         </View>
 
@@ -277,7 +262,6 @@ container: { flex: 1, backgroundColor: palette.cream },
   sectionValue: { fontSize: 16, fontFamily: 'Fraunces_700Bold' },
   cardTitle: { fontSize: 18, color: palette.coffee, fontFamily: 'Fraunces_700Bold', marginBottom: 8 },
   muted: { marginTop: 6, color: palette.coffee },
-  link: { marginTop: 6, color: palette.clay, fontFamily: 'Fraunces_600SemiBold' },
 
   rowBetween: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
     pifTile: { flex: 1, justifyContent: 'space-between', alignItems: 'center' },


### PR DESCRIPTION
## Summary
- Replace the Receipts tab with a Community tab using the existing CommunityScreen.
- Remove Receipts tile from Home and show monthly Community Fund progress instead, updating copy accordingly.
- Simplify router by dropping unused Community stack screen.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5e43b1d548322b5b9fbcb2194e778