### PR TITLE
feat: add account details editing and password reset fallback

### DIFF
--- a/src/navigation/Router.js
+++ b/src/navigation/Router.js
@@ -7,6 +7,7 @@ import MembershipInfoScreen from '../screens/MembershipInfoScreen';
 import MembershipStartScreen from '../screens/MembershipStartScreen';
 import LoyaltyCardCreateScreen from '../screens/LoyaltyCardCreateScreen';
 import ManageSubscriptionScreen from '../screens/ManageSubscriptionScreen';
+import AccountDetailsScreen from '../screens/AccountDetailsScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -18,6 +19,7 @@ export default function Router() {
         <Stack.Screen name="MembershipInfo" component={MembershipInfoScreen} />
         <Stack.Screen name="MembershipStart" component={MembershipStartScreen} />
         <Stack.Screen name="ManageSubscription" component={ManageSubscriptionScreen} />
+        <Stack.Screen name="AccountDetails" component={AccountDetailsScreen} />
         <Stack.Screen name="LoyaltyCardCreate" component={LoyaltyCardCreateScreen} />
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/screens/AccountDetailsScreen.js
+++ b/src/screens/AccountDetailsScreen.js
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TextInput, Alert } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import GlowingGlassButton from '../components/GlowingGlassButton';
+import { palette } from '../design/theme';
+import { supabase } from '../lib/supabase';
+
+export default function AccountDetailsScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSave = async () => {
+    const updates = {};
+    if (email) updates.email = email;
+    if (password) updates.password = password;
+    if (Object.keys(updates).length === 0) {
+      Alert.alert('Nothing to update', 'Enter email or password to change.');
+      return;
+    }
+    const { error } = await supabase.auth.updateUser(updates);
+    if (error) {
+      Alert.alert('Update failed', error.message);
+    } else {
+      Alert.alert('Updated', 'Account details updated.');
+      navigation.goBack();
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Account details</Text>
+        <View style={styles.field}>
+          <Text style={styles.label}>Email</Text>
+          <TextInput
+            value={email}
+            onChangeText={setEmail}
+            placeholder="New email"
+            placeholderTextColor="#A89182"
+            style={styles.input}
+            autoCapitalize="none"
+            keyboardType="email-address"
+          />
+        </View>
+        <View style={styles.field}>
+          <Text style={styles.label}>Password</Text>
+          <TextInput
+            value={password}
+            onChangeText={setPassword}
+            placeholder="New password"
+            placeholderTextColor="#A89182"
+            style={styles.input}
+            secureTextEntry
+          />
+        </View>
+        <View style={{ marginTop:12 }}>
+          <GlowingGlassButton text="Save changes" variant="dark" onPress={handleSave} />
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex:1, backgroundColor: palette.cream },
+  content: { flex:1, padding:20 },
+  title: { fontFamily:'Fraunces_700Bold', fontSize:22, color:palette.coffee, marginBottom:8 },
+  field: { marginTop:12 },
+  label: { color:palette.coffee, marginBottom:6, fontFamily:'Fraunces_600SemiBold' },
+  input: { backgroundColor:'#FFF9F2', borderColor:palette.border, borderWidth:1, borderRadius:12, paddingHorizontal:12, paddingVertical:12, color:palette.coffee },
+});

--- a/src/screens/AdminScreen.js
+++ b/src/screens/AdminScreen.js
@@ -30,6 +30,10 @@ export default function AdminScreen({ navigation }){
         </View>
 
         <View style={{ marginTop:12 }}>
+          <GlowingGlassButton text="Change account details" variant="light" onPress={() => navigation.navigate('AccountDetails')} />
+        </View>
+
+        <View style={{ marginTop:12 }}>
           <GlowingGlassButton text="Sign out" variant="light" onPress={async()=>{
             try { await signOut(); } catch {}
             try { navigation.reset({ index:0, routes:[{ name:'Home' }] }); } catch {}

--- a/src/screens/MembershipStartScreen.js
+++ b/src/screens/MembershipStartScreen.js
@@ -83,7 +83,21 @@ export default function MembershipStartScreen() {
       password,
       options: { data: profile },
     });
-    if (error) { Alert.alert('Sign up failed', error.message); return null; }
+    if (error) {
+      if (/already\s+registered/i.test(error.message)) {
+        Alert.alert(
+          'Account exists',
+          'An account with this email already exists. Reset password?',
+          [
+            { text: 'Cancel', style: 'cancel' },
+            { text: 'Reset password', onPress: handleForgot },
+          ]
+        );
+      } else {
+        Alert.alert('Sign up failed', error.message);
+      }
+      return null;
+    }
     if (data?.user && referral) {
       try { await redeemReferral(referral, data.user.id); } catch {}
     }


### PR DESCRIPTION
## Summary
- offer password reset when signup detects existing account
- allow admins to update email or password via new Account Details screen

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5ec6db61483229cb354dd59890e76