### PR TITLE
feat: add loyalty tiles and free drink counter

### DIFF
--- a/src/components/FreeDrinksCounter.js
+++ b/src/components/FreeDrinksCounter.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { palette } from '../design/theme';
+
+/**
+ * Displays remaining free drinks as a coffee cup that empties by thirds.
+ * @param {Object} props
+ * @param {number} props.count - Number of free drinks remaining (0-3)
+ */
+export default function FreeDrinksCounter({ count = 0 }) {
+  const ratio = Math.max(0, Math.min(1, count / 3));
+  const size = 64;
+  return (
+    <View style={styles.wrap}>
+      <View style={{ width: size, height: size }}>
+        <Ionicons name="cafe-outline" size={size} color={palette.clay} style={styles.cup} />
+        <View style={[styles.fillWrap, { height: size * ratio }]}>
+          <Ionicons name="cafe" size={size} color={palette.clay} />
+        </View>
+      </View>
+      <Text style={styles.label}>{count} / 3 free drinks</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { alignItems: 'center' },
+  cup: { position: 'absolute', top: 0, left: 0 },
+  fillWrap: { position: 'absolute', bottom: 0, overflow: 'hidden', width: '100%' },
+  label: { marginTop: 6, color: palette.clay, fontFamily: 'Fraunces_600SemiBold' },
+});

--- a/src/components/LoyaltyStampTile.js
+++ b/src/components/LoyaltyStampTile.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { palette } from '../design/theme';
+
+/**
+ * Displays loyalty stamp progress as 8 coffee beans (two rows of four).
+ * @param {Object} props
+ * @param {number} props.count - Number of stamps collected.
+ * @param {function} [props.onRedeem] - Called when user taps the redeem button.
+ */
+export default function LoyaltyStampTile({ count = 0, onRedeem }) {
+  const beans = Array.from({ length: 8 }, (_, i) => i < count);
+  const canRedeem = count >= 8;
+  return (
+    <View style={styles.tile}>
+      <Text style={styles.title}>Loyalty</Text>
+      <View style={styles.beansWrap}>
+        {beans.map((filled, i) => (
+          <MaterialCommunityIcons
+            key={i}
+            name={filled ? 'coffee-bean' : 'coffee-bean-outline'}
+            size={24}
+            color={palette.coffee}
+            style={styles.bean}
+          />
+        ))}
+      </View>
+      {canRedeem && (
+        <Pressable style={styles.redeemBtn} onPress={onRedeem}>
+          <Text style={styles.redeemText}>Use free drink!</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  tile: {
+    backgroundColor: palette.paper,
+    borderColor: palette.border,
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 16,
+    alignItems: 'center',
+  },
+  title: {
+    fontFamily: 'Fraunces_700Bold',
+    color: palette.coffee,
+    marginBottom: 8,
+  },
+  beansWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    width: 120,
+    justifyContent: 'space-between',
+  },
+  bean: {
+    width: 24,
+    height: 24,
+    margin: 4,
+  },
+  redeemBtn: {
+    marginTop: 12,
+    backgroundColor: palette.clay,
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+  },
+  redeemText: {
+    color: '#fff',
+    fontFamily: 'Fraunces_700Bold',
+  },
+});

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -7,6 +7,8 @@ import placeholderImg from '../../assets/icon.png';
 import { useIsFocused } from '@react-navigation/native';
 import { palette } from '../design/theme';
 import GlowingGlassButton from '../components/GlowingGlassButton';
+import LoyaltyStampTile from '../components/LoyaltyStampTile';
+import FreeDrinksCounter from '../components/FreeDrinksCounter';
 import { supabase } from '../lib/supabase';
 import { getMembershipSummary } from '../services/membership';
 import { getFundCurrent, getFundProgress } from '../services/community';
@@ -122,16 +124,12 @@ export default function HomeScreen({ navigation }) {
           {signedIn ? (
             <View>
               <View style={{ marginTop: 16 }}>
-                <Text style={styles.sectionLabel}>Loyalty stamps progress</Text>
-                <ProgressBar value={loyalty.current} max={loyalty.target} tint={palette.coffee} track="#F1E3D3" />
-                <Text style={styles.muted}>{loyalty.current} / {loyalty.target} stamps</Text>
+                <LoyaltyStampTile count={loyalty.current} onRedeem={() => {}} />
               </View>
 
               {member?.tier === 'paid' && (
-                <View style={{ marginTop: 16 }}>
-                  <Text style={styles.sectionLabel}>Free drinks remaining</Text>
-                  <ProgressBar value={freebiesLeft} max={3} tint={palette.clay} track="#F1E3D3" />
-                  <Text style={styles.muted}>{freebiesLeft} / 3 drinks</Text>
+                <View style={{ marginTop: 16, alignItems:'center' }}>
+                  <FreeDrinksCounter count={freebiesLeft} />
                 </View>
               )}
 

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -14,10 +14,12 @@ import GlowingGlassButton from '../components/GlowingGlassButton';
 import { getPIFByEmail } from '../services/pif';
 import { createReferral } from '../services/referral';
 import 'react-native-get-random-values';
+import FreeDrinksCounter from '../components/FreeDrinksCounter';
+import LoyaltyStampTile from '../components/LoyaltyStampTile';
 
-function Stat({ label, value, prefix = '', suffix = '' }) {
+function Stat({ label, value, prefix = '', suffix = '', style }) {
   return (
-    <View style={styles.statBox}>
+    <View style={[styles.statBox, style]}>
       <Text style={styles.statValue}>{prefix}{value}{suffix}</Text>
       <Text style={styles.statLabel}>{label}</Text>
     </View>
@@ -87,15 +89,25 @@ export default function MembershipScreen({ navigation }) {
             </View>
 
             {summary.tier === 'paid' && (
-              <View style={styles.gridRow}>
-                <Stat label="Free drinks left" value={stats.freebiesLeft} />
-                <Stat label="Dividends pending" value={Number(stats.dividendsPending).toFixed(2)} prefix="£" />
+              <View style={{ marginTop: 14, alignItems: 'center' }}>
+                <FreeDrinksCounter count={stats.freebiesLeft} />
               </View>
             )}
-            <View style={styles.gridRow}>
-              <Stat label="Loyalty stamps" value={`${stats.loyaltyStamps}/8`} />
-              <Stat label="Pay-it-forward" value={(pifSelfCents/100).toFixed(2)} prefix="£" />
+
+            <View style={{ marginTop: 14 }}>
+              <LoyaltyStampTile count={stats.loyaltyStamps} onRedeem={() => {}} />
             </View>
+
+            {summary.tier === 'paid' ? (
+              <View style={styles.gridRow}>
+                <Stat label="Dividends pending" value={Number(stats.dividendsPending).toFixed(2)} prefix="£" />
+                <Stat label="Pay-it-forward" value={(pifSelfCents/100).toFixed(2)} prefix="£" />
+              </View>
+            ) : (
+              <View style={{ marginTop: 14 }}>
+                <Stat label="Pay-it-forward" value={(pifSelfCents/100).toFixed(2)} prefix="£" style={{ marginRight: 0 }} />
+              </View>
+            )}
 
             <View style={{ marginTop: 16 }}>
               <Text style={styles.referralText}>


### PR DESCRIPTION
## Summary
- show free drink cup icon that empties as perks are used
- display loyalty progress tile with coffee bean stamps
- surface new components on home and membership screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a609ee23fc8322b5d128ce28ebfa2d