### PR TITLE
fix: replace undefined placeholder image with app icon

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -215,7 +215,12 @@ export default function HomeScreen({ navigation }) {
             </View>
           ) : (
             <View style={styles.igPolaroid}>
-              <Image source={placeholderImg} style={styles.igImage} resizeMode="cover" />
+              {/* Fallback to app icon when no Instagram image is available */}
+              <Image
+                source={require('../../assets/icon.png')}
+                style={styles.igImage}
+                resizeMode="cover"
+              />
               <Text style={styles.muted}>Unable to load latest post.</Text>
             </View>
           )}


### PR DESCRIPTION
## Summary
- fix Instagram placeholder by replacing undefined variable with app icon fallback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a636d23fc483229a90135184434b57