### PR TITLE
feat: improve QR carousel and sync loyalty stamps

### DIFF
--- a/src/components/LoyaltyStampTile.js
+++ b/src/components/LoyaltyStampTile.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 import { palette } from '../design/theme';
 
-export default function LoyaltyStampTile({ count = 0, onRedeem }) {
-  const beans = Array.from({ length: 8 }, (_, i) => i < count);
+export default function LoyaltyStampTile({ count = 0 }) {
+  const beans = Array.from({ length: 8 }, (_, i) => i < (count % 8));
   const canRedeem = count >= 8;
   const Bean = ({ filled }) => (
     <Svg width={24} height={24} viewBox="0 0 24 24" style={styles.bean}>
@@ -52,11 +52,6 @@ export default function LoyaltyStampTile({ count = 0, onRedeem }) {
           />
         </Svg>
       </View>
-      {canRedeem && (
-        <Pressable style={styles.redeemBtn} onPress={onRedeem}>
-          <Text style={styles.redeemText}>Use free drink!</Text>
-        </Pressable>
-      )}
     </View>
   );
 }
@@ -82,15 +77,4 @@ const styles = StyleSheet.create({
   beansRow: { flexDirection: 'row' },
   bean: { width: 24, height: 24, margin: 4 },
   bigBean: { marginLeft: 12 },
-  redeemBtn: {
-    marginTop: 12,
-    backgroundColor: palette.clay,
-    borderRadius: 8,
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-  },
-  redeemText: {
-    color: '#fff',
-    fontFamily: 'Fraunces_700Bold',
-  },
 });

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -11,7 +11,7 @@ import FreeDrinksCounter from '../components/FreeDrinksCounter';
 import { supabase } from '../lib/supabase';
 import { getMembershipSummary } from '../services/membership';
 import { getFundCurrent, getFundProgress } from '../services/community';
-import { getToday, getPayItForward, getFreeDrinkProgress, openInstagramProfile, getWeeklyHours, getLatestInstagramPost } from '../services/homeData';
+import { getToday, getPayItForward, openInstagramProfile, getWeeklyHours, getLatestInstagramPost } from '../services/homeData';
 import { getMyStats } from '../services/stats';
 import { getCMS } from '../services/cms';
 
@@ -48,6 +48,8 @@ export default function HomeScreen({ navigation }) {
   useEffect(() => {
     getFundProgress().then(setFund).catch(() => setFund({ progress: 0, total_cents: 0, goal_cents: 0 }));
     getWeeklyHours().then(setWeekHours).catch(() => setWeekHours([]));
+    if (globalThis.freebiesLeft !== undefined) setFreebiesLeft(globalThis.freebiesLeft);
+    if (globalThis.loyaltyStamps !== undefined) setLoyalty({ current: globalThis.loyaltyStamps, target: 8 });
     let mounted = true;
     (async () => {
       try {
@@ -57,8 +59,13 @@ export default function HomeScreen({ navigation }) {
       try { const f = await getFundCurrent(); if (mounted && f) setFund(f); } catch {}
       try { const t = await getToday(); if (mounted) setToday(t); } catch {}
       try { const s = await getPIFStats(); if (mounted) setPif(s); } catch {}
-      try { const d = await getFreeDrinkProgress(); if (mounted) setLoyalty(d); } catch {}
-      try { const stats = await getMyStats(); if (mounted) setFreebiesLeft(stats.freebiesLeft || 0); } catch {}
+      try {
+        const stats = await getMyStats();
+        if (mounted) {
+          setFreebiesLeft(stats.freebiesLeft || 0);
+          setLoyalty({ current: stats.loyaltyStamps || 0, target: 8 });
+        }
+      } catch {}
       try { const ig = await getLatestInstagramPost(); if (mounted) setIgPost(ig); } catch {}
       try {
         const cms = await getCMS();

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ScrollView, View, Text, StyleSheet, Pressable, Share } from 'react-native';
+import { ScrollView, View, Text, StyleSheet, Share, Pressable } from 'react-native';
 import * as Sharing from 'expo-sharing';
 import * as FileSystem from 'expo-file-system';
 import membershipPassBase64 from '../../assets/membershipPassBase64';
 import { useFocusEffect } from '@react-navigation/native';
 import QRCode from 'react-native-qrcode-svg';
+import PagerView from 'react-native-pager-view';
 import { palette } from '../design/theme';
 import { supabase } from '../lib/supabase';
 import { getMembershipSummary } from '../services/membership';
@@ -30,11 +31,18 @@ export default function MembershipScreen({ navigation }) {
   const [summary, setSummary] = useState({ signedIn:false, tier:'free', status:'none', next_billing_at:null });
   const [pifSelfCents,setPifSelfCents]=useState(0);
   const [stats, setStats] = useState({ freebiesLeft:3, dividendsPending:0, loyaltyStamps:0, payItForwardContrib:0, communityContrib:0 });
+  const [vouchers, setVouchers] = useState([]);
+  const [page, setPage] = useState(0);
   const [user, setUser] = useState(null);
 
   const refresh = useCallback(async () => {
     try { const m = await getMembershipSummary(); if (m) setSummary(m); } catch {}
-    try { const s = await getMyStats(); setStats(s); } catch {}
+    try {
+      const s = await getMyStats();
+      setStats(s);
+      globalThis.freebiesLeft = s.freebiesLeft;
+      globalThis.loyaltyStamps = s.loyaltyStamps;
+    } catch {}
     if (supabase) {
       try { const u = await supabase.auth.getUser(); setUser(u?.data?.user || null); } catch {}
     } else {
@@ -42,10 +50,36 @@ export default function MembershipScreen({ navigation }) {
     }
   }, []);
 
-  useEffect(() => { refresh(); }, [refresh]);
+  useEffect(() => {
+    setStats(prev => ({
+      ...prev,
+      freebiesLeft: globalThis.freebiesLeft ?? prev.freebiesLeft,
+      loyaltyStamps: globalThis.loyaltyStamps ?? prev.loyaltyStamps,
+    }));
+    refresh();
+  }, [refresh]);
   useFocusEffect(useCallback(() => { let on = true; (async()=>{ if(on) await refresh(); })(); return () => { on = false; }; }, [refresh]));
 
   const payload = user ? `ruminate:${user.id}` : 'ruminate:member';
+
+  useEffect(() => {
+    setVouchers(v => {
+      if (v.length < stats.freebiesLeft) {
+        const needed = stats.freebiesLeft - v.length;
+        return [
+          ...v,
+          ...Array.from({ length: needed }, () =>
+            crypto?.randomUUID?.() || Math.random().toString(36).slice(2, 10)
+          ),
+        ];
+      }
+      if (v.length > stats.freebiesLeft) {
+        return v.slice(0, stats.freebiesLeft);
+      }
+      return v;
+    });
+  }, [stats.freebiesLeft]);
+
 
   useEffect(()=>{ 
     let m=true; 
@@ -64,7 +98,12 @@ export default function MembershipScreen({ navigation }) {
   const [notice, setNotice] = useState('');
   useEffect(() => {
     if (stats.loyaltyStamps >= 8) {
-      setStats(s => ({ ...s, loyaltyStamps: s.loyaltyStamps - 8, freebiesLeft: s.freebiesLeft + 1 }));
+      setStats(s => {
+        const updated = { ...s, loyaltyStamps: s.loyaltyStamps - 8, freebiesLeft: s.freebiesLeft + 1 };
+        globalThis.freebiesLeft = updated.freebiesLeft;
+        globalThis.loyaltyStamps = updated.loyaltyStamps;
+        return updated;
+      });
       setNotice("You've earned a free drink!");
       const t = setTimeout(() => setNotice(''), 4000);
       return () => clearTimeout(t);
@@ -81,6 +120,8 @@ export default function MembershipScreen({ navigation }) {
     }
   }, []);
 
+  const totalPages = 1 + vouchers.length;
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <ScrollView contentContainerStyle={styles.content}>
@@ -89,15 +130,46 @@ export default function MembershipScreen({ navigation }) {
 
         {summary.signedIn ? (
           <>
-            <View style={styles.card}>
-              <Text style={styles.cardTitle}>Your QR</Text>
-              <View style={styles.qrWrap}>
-                <QRCode value={payload} size={180} />
-              </View>
-              <Text style={styles.mutedSmall}>Show at the counter to redeem perks and stamps.</Text>
-              <View style={{ marginTop: 12 }}>
-                <GlowingGlassButton text="Add to Wallet" variant="dark" onPress={handleAddToWallet} />
-              </View>
+            <View style={{ marginTop: 14 }}>
+              <PagerView
+                style={styles.carousel}
+                initialPage={0}
+                onPageSelected={(e) => setPage(e.nativeEvent.position)}
+              >
+                <View key="member" style={[styles.card, styles.qrCard]}>
+                  <Text style={styles.cardTitle}>Your QR</Text>
+                  <View style={styles.qrWrap}>
+                    <QRCode value={payload} size={180} />
+                  </View>
+                  <Text style={styles.mutedSmall}>Show at the counter to redeem perks and stamps.</Text>
+                  <View style={{ marginTop: 12 }}>
+                    <GlowingGlassButton text="Add to Wallet" variant="dark" onPress={handleAddToWallet} />
+                  </View>
+                </View>
+
+                {vouchers.map((code) => (
+                  <View key={code} style={[styles.card, styles.qrCard, styles.voucherCard]}>
+                    <Text style={[styles.cardTitle, styles.voucherTitle]}>Drink voucher</Text>
+                    <View style={styles.qrWrap}>
+                      <QRCode value={code} size={180} />
+                    </View>
+                    <Text style={[styles.mutedSmall, styles.voucherText]}>Show at the counter to redeem.</Text>
+                  </View>
+                ))}
+              </PagerView>
+              {totalPages > 1 && (
+                <>
+                  <Text style={styles.swipePrompt}>Swipe to see your drink vouchers</Text>
+                  <View style={styles.dots}>
+                    {Array.from({ length: totalPages }).map((_, i) => (
+                      <View
+                        key={i}
+                        style={[styles.dot, i === page && styles.dotActive]}
+                      />
+                    ))}
+                  </View>
+                </>
+              )}
             </View>
 
             {summary.tier === 'paid' && (
@@ -107,7 +179,7 @@ export default function MembershipScreen({ navigation }) {
             )}
 
             <View style={{ marginTop: 14 }}>
-              <LoyaltyStampTile count={stats.loyaltyStamps} onRedeem={() => {}} />
+              <LoyaltyStampTile count={stats.loyaltyStamps} />
             </View>
 
             {summary.tier === 'paid' ? (
@@ -211,7 +283,16 @@ const styles = StyleSheet.create({
   statValue:{ fontSize:28, color:palette.clay, fontFamily:'Fraunces_700Bold' },
   statLabel:{ marginTop:6, color:palette.coffee, fontFamily:'Fraunces_600SemiBold' },
   notice:{ backgroundColor:palette.paper, borderColor:palette.border, borderWidth:1, borderRadius:10, padding:10, marginTop:12, textAlign:'center', color:palette.clay, fontFamily:'Fraunces_700Bold' },
-  qrWrap:{ alignItems:'center', justifyContent:'center', paddingVertical:12 },
+  qrWrap:{ alignItems:'center', justifyContent:'center', paddingVertical:12, height:300 },
+  carousel:{ height:440, width:'100%' },
+  qrCard:{ marginTop:0, flex:1 },
+  voucherCard:{ backgroundColor:palette.coffee, borderColor:palette.coffee },
+  voucherTitle:{ color:palette.paper },
+  voucherText:{ color:palette.paper, textAlign:'center' },
+  swipePrompt:{ textAlign:'center', color:palette.coffee, marginTop:8, fontFamily:'Fraunces_600SemiBold' },
+  dots:{ flexDirection:'row', justifyContent:'center', marginTop:4 },
+  dot:{ width:8, height:8, borderRadius:4, backgroundColor:palette.border, marginHorizontal:3 },
+  dotActive:{ backgroundColor:palette.coffee },
   cta:{ borderRadius:14, paddingVertical:14, alignItems:'center', justifyContent:'center' },
   ctaPrimary:{ backgroundColor: palette.clay, borderColor: palette.border, borderWidth: 1 },
   ctaPrimaryText:{ color:'#fff', fontFamily:'Fraunces_700Bold', fontSize:16 },

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -28,7 +28,7 @@ export async function getMyStats() {
     ]);
 
     if (error) {
-      return {
+      const result = {
         freebiesLeft: (profile?.free_drinks ?? 0) + 3,
         dividendsPending: 0,
         loyaltyStamps: 0,
@@ -36,9 +36,12 @@ export async function getMyStats() {
         communityContrib: 0,
         discountCredits: profile?.discount_credits ?? 0,
       };
+      globalThis.freebiesLeft = result.freebiesLeft;
+      globalThis.loyaltyStamps = result.loyaltyStamps;
+      return result;
     }
 
-    return {
+    const result = {
       freebiesLeft: (data?.freebiesLeft ?? 3) + (profile?.free_drinks ?? 0),
       dividendsPending: data?.dividendsPending ?? 0,
       loyaltyStamps: data?.loyaltyStamps ?? data?.discountUses ?? 0,
@@ -46,8 +49,11 @@ export async function getMyStats() {
       communityContrib: data?.communityContrib ?? 0,
       discountCredits: profile?.discount_credits ?? 0,
     };
+    globalThis.freebiesLeft = result.freebiesLeft;
+    globalThis.loyaltyStamps = result.loyaltyStamps;
+    return result;
   } catch {
-    return {
+    const result = {
       freebiesLeft: 3,
       dividendsPending: 0,
       loyaltyStamps: 0,
@@ -55,5 +61,8 @@ export async function getMyStats() {
       communityContrib: 0,
       discountCredits: 0,
     };
+    globalThis.freebiesLeft = result.freebiesLeft;
+    globalThis.loyaltyStamps = result.loyaltyStamps;
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- enlarge QR carousel tiles to avoid Apple Wallet cutoff
- style drink voucher slides dark brown with centered redemption hint
- share loyalty stamps and free drink counts across screens via global stats

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68a6da536c5c83228ad80e9275b49642