### PR TITLE
Link Instagram tile to latest post

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Create an `.env` file based on `.env.example` and provide values for the variables below:
 
 
-- `EXPO_PUBLIC_INSTAGRAM_FEED_URL` – endpoint that returns the latest Instagram post as JSON (`{ image, caption }`). Used on the Home screen to display the most recent post.
+- `EXPO_PUBLIC_INSTAGRAM_FEED_URL` – endpoint that returns the latest Instagram post as JSON (`{ image, caption, url }`). Used on the Home screen to display and link to the most recent post.
 
 
 Other Supabase-related variables are also required; see `.env.example` for defaults.

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -11,7 +11,7 @@ import FreeDrinksCounter from '../components/FreeDrinksCounter';
 import { supabase } from '../lib/supabase';
 import { getMembershipSummary } from '../services/membership';
 import { getFundCurrent, getFundProgress } from '../services/community';
-import { getToday, getPayItForward, openInstagramProfile, getWeeklyHours, getLatestInstagramPost } from '../services/homeData';
+import { getToday, getPayItForward, openInstagramUrl, getWeeklyHours, getLatestInstagramPost } from '../services/homeData';
 import { getMyStats } from '../services/stats';
 import { getCMS } from '../services/cms';
 
@@ -43,7 +43,7 @@ export default function HomeScreen({ navigation }) {
   const [loyalty, setLoyalty] = useState({ current: 0, target: 8 });
   const [freebiesLeft, setFreebiesLeft] = useState(0);
   const [rumiQuote, setRumiQuote] = useState(null);
-  const [igPost, setIgPost] = useState({ image: null, caption: '' });
+  const [igPost, setIgPost] = useState({ image: null, caption: '', url: null });
 
   useEffect(() => {
     getFundProgress().then(setFund).catch(() => setFund({ progress: 0, total_cents: 0, goal_cents: 0 }));
@@ -197,27 +197,29 @@ export default function HomeScreen({ navigation }) {
         <View style={styles.card}>
           <Text style={styles.cardTitle}>Latest on Instagram</Text>
           {igPost?.image ? (
-            <View style={styles.igPolaroid}>
-              <Image
-                source={{ uri: igPost.image }}
-                style={styles.igImage}
-                resizeMode="cover"
-                onError={async () => {
-                  try {
-                    const cached = await AsyncStorage.getItem('latestIgPost');
-                    if (cached) {
-                      const parsed = JSON.parse(cached);
-                      if (parsed?.image && parsed.image !== igPost.image) {
-                        setIgPost(parsed);
-                        return;
+            <Pressable onPress={() => openInstagramUrl(igPost.url)}>
+              <View style={styles.igPolaroid}>
+                <Image
+                  source={{ uri: igPost.image }}
+                  style={styles.igImage}
+                  resizeMode="cover"
+                  onError={async () => {
+                    try {
+                      const cached = await AsyncStorage.getItem('latestIgPost');
+                      if (cached) {
+                        const parsed = JSON.parse(cached);
+                        if (parsed?.image && parsed.image !== igPost.image) {
+                          setIgPost(parsed);
+                          return;
+                        }
                       }
-                    }
-                  } catch {}
-                  setIgPost({ image: null, caption: '' });
-                }}
-              />
-              {igPost?.caption ? <Text style={styles.igCaption}>{igPost.caption}</Text> : null}
-            </View>
+                    } catch {}
+                    setIgPost({ image: null, caption: '', url: null });
+                  }}
+                />
+                {igPost?.caption ? <Text style={styles.igCaption}>{igPost.caption}</Text> : null}
+              </View>
+            </Pressable>
           ) : (
             <View style={styles.igPolaroid}>
               {/* Fallback to app icon when no Instagram image is available */}
@@ -229,7 +231,7 @@ export default function HomeScreen({ navigation }) {
               <Text style={styles.muted}>Unable to load latest post.</Text>
             </View>
           )}
-          <Pressable onPress={openInstagramProfile} style={styles.igButton}>
+          <Pressable onPress={() => openInstagramUrl(igPost?.url)} style={styles.igButton}>
             <Text style={styles.igButtonText}>View on Instagram</Text>
           </Pressable>
         </View>

--- a/src/services/homeData.js
+++ b/src/services/homeData.js
@@ -93,15 +93,24 @@ export async function getWeeklyHours(){
 export async function getPayItForward(){ return { available:7, contributed:124 }; }
 export async function getFreeDrinkProgress(){ return { current:3, target:8 }; }
 
-export async function openInstagramProfile(){ 
-  const app='instagram://user?username=ruminatecafe'; 
-  const web='https://www.instagram.com/ruminatecafe/'; 
-  try{ 
-    const can=await Linking.canOpenURL(app); 
-    await Linking.openURL(can?app:web); 
-  } catch { 
-    Linking.openURL(web); 
-  } 
+export async function openInstagramProfile(){
+  const app='instagram://user?username=ruminatecafe';
+  const web='https://www.instagram.com/ruminatecafe/';
+  try{
+    const can=await Linking.canOpenURL(app);
+    await Linking.openURL(can?app:web);
+  } catch {
+    Linking.openURL(web);
+  }
+}
+
+export async function openInstagramUrl(url){
+  if(!url) return openInstagramProfile();
+  try{
+    await Linking.openURL(url);
+  }catch{
+    openInstagramProfile();
+  }
 }
 
 export async function getLatestInstagramPost(){
@@ -109,7 +118,8 @@ export async function getLatestInstagramPost(){
   const endpoint=process.env.EXPO_PUBLIC_INSTAGRAM_FEED_URL;
   try{
     if(!endpoint) throw new Error('no endpoint');
-    const res=await fetch(endpoint);
+    const url=endpoint+(endpoint.includes('?')?'&':'?')+`t=${Date.now()}`;
+    const res=await fetch(url);
     if(!res.ok) throw new Error('bad status');
     const data=await res.json();
 
@@ -118,7 +128,8 @@ export async function getLatestInstagramPost(){
       if(!item) return null;
       const image=item.image||item.image_url||item.imageUrl||item.media_url||item.url;
       const caption=item.caption||item.text||'';
-      return typeof image==='string'?{image,caption}:null;
+      const link=item.permalink||item.url||item.link||null;
+      return typeof image==='string'?{image,caption,url:link}:null;
     };
 
     const post=pickPost(data);
@@ -128,6 +139,6 @@ export async function getLatestInstagramPost(){
     return post;
   }catch{
     try{ const cached=await AsyncStorage.getItem(cacheKey); if(cached) return JSON.parse(cached); }catch{}
-    return { image:null, caption:'' };
+    return { image:null, caption:'', url:null };
   }
 }


### PR DESCRIPTION
## Summary
- Fetch and store Instagram post permalink and expose new `openInstagramUrl` helper.
- Show Instagram image as a link to the specific post and use URL-aware button on Home screen.
- Document updated feed response structure including `url` property.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6e5853ed48322aac121961dfb2e6f