### PR TITLE
Display free drink balance from Supabase

### DIFF
--- a/src/components/FreeDrinksCounter.js
+++ b/src/components/FreeDrinksCounter.js
@@ -5,7 +5,9 @@ import Svg, { Circle } from 'react-native-svg';
 import { palette } from '../design/theme';
 
 export default function FreeDrinksCounter({ count = 0 }) {
-  const ratio = Math.max(0, Math.min(1, count / 3));
+  const limit = 3;
+  const remaining = Math.max(0, Math.min(limit, count));
+  const ratio = remaining / limit;
   const size = 64;
   const radius = 28;
   const circumference = 2 * Math.PI * radius;
@@ -29,7 +31,7 @@ export default function FreeDrinksCounter({ count = 0 }) {
           />
         </Svg>
       </View>
-      <Text style={styles.label}>{count} / 3 remaining</Text>
+      <Text style={styles.label}>{`${remaining} / ${limit} remaining this month`}</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- Show remaining monthly free drinks based on Supabase data
- Clamp free drink counter and append `this month`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a72d006e408322a4c904d081c7e467