### PR TITLE
fix: wire reward stats to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Create an `.env` file based on `.env.example` and provide values for the variabl
 
 
 Other Supabase-related variables are also required; see `.env.example` for defaults.
+
+## Reward utilities
+
+Run `node scripts/grant-rewards.js <email> <freeDrinks> <loyaltyStamps>` with `SUPABASE_SERVICE_ROLE_KEY` set to grant free drinks and loyalty stamps.
+
+Run `node scripts/reset-rewards.js <email>` with `SUPABASE_SERVICE_ROLE_KEY` to remove all free drinks and loyalty stamps for the given user.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "mock": "node generatePasses.js && expo start"
+    "mock": "node generatePasses.js && expo start",
+    "grant-rewards": "node scripts/grant-rewards.js",
+    "reset-rewards": "node scripts/reset-rewards.js"
   },
   "dependencies": {
     "@expo-google-fonts/fraunces": "^0.4.0",

--- a/scripts/grant-rewards.js
+++ b/scripts/grant-rewards.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+
+const [email, freebies = '0', stamps = '0'] = process.argv.slice(2);
+if (!email) {
+  console.error('Usage: node grant-rewards.js <email> <freeDrinks> <loyaltyStamps>');
+  process.exit(1);
+}
+
+const url = process.env.SUPABASE_URL || process.env.EXPO_PUBLIC_SUPABASE_URL || 'https://eamewialuovzguldcdcf.supabase.co';
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
+if (!serviceKey) {
+  console.error('Missing SUPABASE_SERVICE_ROLE_KEY.');
+  process.exit(1);
+}
+
+const admin = createClient(url, serviceKey);
+
+(async () => {
+  const { data: listRes, error: listErr } = await admin.auth.admin.listUsers();
+  if (listErr) {
+    console.error('Failed to list users.');
+    process.exit(1);
+  }
+  const user = listRes?.users?.find(u => u.email?.toLowerCase() === email.toLowerCase());
+  if (!user) {
+    console.error('User not found.');
+    process.exit(1);
+  }
+  const userId = user.id;
+
+  const freeCount = parseInt(freebies, 10);
+  const stampCount = parseInt(stamps, 10);
+
+  if (freeCount > 0) {
+    const vouchers = Array.from({ length: freeCount }, () => ({ user_id: userId, code: randomUUID() }));
+    await admin.from('drink_vouchers').insert(vouchers);
+  }
+
+  if (stampCount > 0) {
+    await admin.from('loyalty_stamps').insert({ user_id: userId, stamps: stampCount });
+  }
+
+  console.log(`Granted ${freeCount} free drinks and ${stampCount} loyalty stamps to ${email}`);
+})();

--- a/src/components/FreeDrinksCounter.js
+++ b/src/components/FreeDrinksCounter.js
@@ -29,7 +29,7 @@ export default function FreeDrinksCounter({ count = 0 }) {
           />
         </Svg>
       </View>
-      <Text style={styles.label}>{count} / 3 remaining</Text>
+      <Text style={styles.label}>{count === 1 ? '1 free drink' : `${count} free drinks`}</Text>
     </View>
   );
 }

--- a/src/components/LoyaltyStampTile.js
+++ b/src/components/LoyaltyStampTile.js
@@ -4,7 +4,8 @@ import Svg, { Path } from 'react-native-svg';
 import { palette } from '../design/theme';
 
 export default function LoyaltyStampTile({ count = 0 }) {
-  const beans = Array.from({ length: 8 }, (_, i) => i < (count % 8));
+  const filled = Math.max(0, Math.floor(count % 8));
+  const beans = Array.from({ length: 8 }, (_, i) => i < filled);
   const canRedeem = count >= 8;
   const Bean = ({ filled }) => (
     <Svg width={24} height={24} viewBox="0 0 24 24" style={styles.bean}>

--- a/src/screens/AdminScreen.js
+++ b/src/screens/AdminScreen.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { palette } from '../design/theme';
 import GlowingGlassButton from '../components/GlowingGlassButton';
 import { signOut } from '../services/membership';
 import { supabase } from '../lib/supabase';
 
 export default function AdminScreen({ navigation }){
+  const insets = useSafeAreaInsets();
   const handleDelete = async () => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
@@ -19,9 +20,9 @@ export default function AdminScreen({ navigation }){
   };
 
   return (
-    <SafeAreaView style={styles.container} edges={['top']}>
+    <SafeAreaView style={styles.container} edges={['left','right']}>
+      <View style={[styles.header, { paddingTop: insets.top }]}><Text style={styles.headerTitle}>Admin</Text></View>
       <View style={styles.content}>
-        <Text style={styles.title}>Admin</Text>
         <Text style={styles.p}>Moderate activity and manage the café workflow.</Text>
 
         <View style={{ marginTop:20 }}>
@@ -64,8 +65,19 @@ export default function AdminScreen({ navigation }){
 }
 
 const styles = StyleSheet.create({
-  container: { flex:1 },
+  container: { flex:1, backgroundColor: 'transparent' },
+  header: {
+    backgroundColor: palette.cream,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  headerTitle: { fontSize: 20, color: '#3E2723', fontFamily: 'Fraunces_700Bold' },
   content: { flex:1, padding:20 },
-  title: { fontFamily:'Fraunces_700Bold', fontSize:22, color:palette.coffee, marginBottom:8 },
   p: { color:palette.coffee, fontSize:16 }
 });

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -291,10 +291,10 @@ const styles = StyleSheet.create({
   hoursDay: { fontFamily: 'Fraunces_700Bold', color: palette.coffee, fontSize: 14 },
   hoursTime: { fontFamily: 'Fraunces_600SemiBold', color: '#6b5a54', fontSize: 14 },
   header: {
-    backgroundColor: 'transparent',
+    backgroundColor: palette.cream,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingBottom: 12,
+    paddingVertical: 12,
     shadowColor: '#000',
     shadowOpacity: 0.15,
     shadowOffset: { width: 0, height: 2 },

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -33,7 +33,7 @@ export default function MembershipScreen({ navigation }) {
   const insets = useSafeAreaInsets();
   const [summary, setSummary] = useState({ signedIn: false, tier: 'free', status: 'none', next_billing_at: null });
   const [pifSelfCents, setPifSelfCents] = useState(0);
-  const [stats, setStats] = useState({ freebiesLeft: 3, dividendsPending: 0, loyaltyStamps: 0, payItForwardContrib: 0, communityContrib: 0 });
+  const [stats, setStats] = useState({ freebiesLeft: 0, dividendsPending: 0, loyaltyStamps: 0, payItForwardContrib: 0, communityContrib: 0 });
   const [vouchers, setVouchers] = useState([]);
   const [page, setPage] = useState(0);
   const [user, setUser] = useState(null);
@@ -46,6 +46,7 @@ export default function MembershipScreen({ navigation }) {
       setStats(s);
       globalThis.freebiesLeft = s.freebiesLeft;
       globalThis.loyaltyStamps = s.loyaltyStamps;
+      await syncVouchers(s.freebiesLeft);
     } catch {}
     if (supabase) {
       try {

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -3,7 +3,7 @@ import { supabase, hasSupabase } from '../lib/supabase';
 export async function getMyStats() {
   if (!hasSupabase || !supabase) {
     return {
-      freebiesLeft: 3,
+      freebiesLeft: 0,
       dividendsPending: 0,
       loyaltyStamps: 0,
       payItForwardContrib: 0,
@@ -15,7 +15,7 @@ export async function getMyStats() {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.user) {
       return {
-        freebiesLeft: 3,
+        freebiesLeft: 0,
         dividendsPending: 0,
         loyaltyStamps: 0,
         payItForwardContrib: 0,
@@ -29,7 +29,7 @@ export async function getMyStats() {
 
     if (error) {
       const result = {
-        freebiesLeft: (profile?.free_drinks ?? 0) + 3,
+        freebiesLeft: (profile?.free_drinks ?? 0),
         dividendsPending: 0,
         loyaltyStamps: 0,
         payItForwardContrib: 0,
@@ -42,7 +42,7 @@ export async function getMyStats() {
     }
 
     const result = {
-      freebiesLeft: (data?.freebiesLeft ?? 3) + (profile?.free_drinks ?? 0),
+      freebiesLeft: (data?.freebiesLeft ?? 0) + (profile?.free_drinks ?? 0),
       dividendsPending: data?.dividendsPending ?? 0,
       loyaltyStamps: data?.loyaltyStamps ?? data?.discountUses ?? 0,
       payItForwardContrib: data?.payItForwardContrib ?? 0,
@@ -54,7 +54,7 @@ export async function getMyStats() {
     return result;
   } catch {
     const result = {
-      freebiesLeft: 3,
+      freebiesLeft: 0,
       dividendsPending: 0,
       loyaltyStamps: 0,
       payItForwardContrib: 0,

--- a/supabase/functions/member-qrs/index.ts
+++ b/supabase/functions/member-qrs/index.ts
@@ -1,8 +1,8 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const SB_URL = Deno.env.get("SB_URL")!;
-const SB_SERVICE_ROLE_KEY = Deno.env.get("SB_SERVICE_ROLE_KEY")!;
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
 function cors() {
   return {
@@ -24,7 +24,7 @@ serve(async (req: Request) => {
     });
   }
 
-  const admin = createClient(SB_URL, SB_SERVICE_ROLE_KEY);
+  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
   // fetch existing unredeemed vouchers
   const { data: vouchers } = await admin

--- a/supabase/functions/vouchers-sync/index.ts
+++ b/supabase/functions/vouchers-sync/index.ts
@@ -1,9 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const SB_URL = Deno.env.get("SB_URL")!;
-const SB_ANON_KEY = Deno.env.get("SB_ANON_KEY")!;
-const SB_SERVICE_ROLE_KEY = Deno.env.get("SB_SERVICE_ROLE_KEY")!;
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
 function cors() {
   return {
@@ -22,19 +22,23 @@ serve(async (req: Request) => {
   const desired = Math.max(0, parseInt(body?.freebiesLeft) || 0);
 
   const authHeader = req.headers.get("Authorization") ?? "";
-  const auth = createClient(SB_URL, SB_ANON_KEY, { global: { headers: { Authorization: authHeader } } });
+  const auth = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, { global: { headers: { Authorization: authHeader } } });
   const { data: { user } } = await auth.auth.getUser();
   if (!user) return new Response("Unauthorized", { status: 401, headers: cors() });
 
-  const admin = createClient(SB_URL, SB_SERVICE_ROLE_KEY);
-  const { data: existing } = await admin.from("vouchers").select("code").eq("user_id", user.id).eq("redeemed", false);
+  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const { data: existing } = await admin
+    .from("drink_vouchers")
+    .select("code")
+    .eq("user_id", user.id)
+    .eq("redeemed", false);
   const codes = existing?.map(r => r.code) ?? [];
 
   if (codes.length < desired) {
     const toCreate = desired - codes.length;
     const newCodes = Array.from({ length: toCreate }, () => crypto.randomUUID());
     const inserts = newCodes.map(code => ({ code, user_id: user.id }));
-    await admin.from("vouchers").insert(inserts);
+    await admin.from("drink_vouchers").insert(inserts);
     codes.push(...newCodes);
   }
 


### PR DESCRIPTION
## Summary
- show only actual free-drink vouchers instead of always defaulting to three
- document and expose reward grant/reset utilities via npm scripts
- label free-drink tile with available count and ensure loyalty beans fill accurately

## Testing
- ❌ `npm run grant-rewards -- q06mrashid@gmail.com 2 2` (fetch failed: ENETUNREACH)
- ❌ `npm run reset-rewards -- q06mrashid@gmail.com` (fetch failed: ENETUNREACH)
- ❌ `npm test` (Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a728ef12d08322957ebec74c84ec13