### PR TITLE
Refresh rewards from Supabase tables and show free drink tile when available

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -79,7 +79,7 @@ export default function HomeScreen({ navigation }) {
     })();
 
     return () => { mounted = false; };
-  }, [isFocused]);
+  }, [isFocused, member.signedIn]);
 
   useEffect(() => {
     if (!supabase?.auth) {
@@ -141,7 +141,7 @@ export default function HomeScreen({ navigation }) {
                 <LoyaltyStampTile count={loyalty.current} onRedeem={() => {}} />
               </View>
 
-              {member?.tier === 'paid' && (
+              {(member?.tier === 'paid' || freebiesLeft > 0) && (
                 <View style={{ marginTop: 16 }}>
                   <FreeDrinksCounter count={freebiesLeft} />
                 </View>

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -22,32 +22,46 @@ export async function getMyStats() {
         communityContrib: 0,
       };
     }
-    const [{ data: profile }, { data, error }] = await Promise.all([
-      supabase.from('profiles').select('free_drinks, discount_credits').eq('user_id', session.user.id).maybeSingle(),
-      supabase.functions.invoke('me-stats', { body: {} })
+    const [
+      { data: profile },
+      { data: statsData, error: statsError },
+      { count: voucherCount },
+      { data: stampRows },
+    ] = await Promise.all([
+      supabase
+        .from('profiles')
+        .select('free_drinks, discount_credits')
+        .eq('user_id', session.user.id)
+        .maybeSingle(),
+      supabase.functions.invoke('me-stats', { body: {} }),
+        supabase
+          .from('drink_vouchers')
+          .select('id', { count: 'exact', head: true })
+          .eq('user_id', session.user.id)
+          .or('redeemed.eq.false,redeemed.is.null'),
+      supabase
+        .from('loyalty_stamps')
+        .select('stamps')
+        .eq('user_id', session.user.id),
     ]);
 
-    if (error) {
-      const result = {
-        freebiesLeft: (profile?.free_drinks ?? 0),
-        dividendsPending: 0,
-        loyaltyStamps: 0,
-        payItForwardContrib: 0,
-        communityContrib: 0,
-        discountCredits: profile?.discount_credits ?? 0,
-      };
-      globalThis.freebiesLeft = result.freebiesLeft;
-      globalThis.loyaltyStamps = result.loyaltyStamps;
-      return result;
-    }
+    const edgeStats = statsError ? {} : statsData || {};
+    const freebiesLeft = (profile?.free_drinks ?? 0) + (voucherCount ?? 0);
+    const dividendsPending = edgeStats.dividendsPending ?? 0;
+    const loyaltyStamps =
+      (edgeStats.loyaltyStamps ?? edgeStats.discountUses ?? 0) +
+      (stampRows ?? []).reduce((sum, r) => sum + (r.stamps || 0), 0);
+    const payItForwardContrib = edgeStats.payItForwardContrib ?? 0;
+    const communityContrib = edgeStats.communityContrib ?? 0;
+    const discountCredits = profile?.discount_credits ?? 0;
 
     const result = {
-      freebiesLeft: (data?.freebiesLeft ?? 0) + (profile?.free_drinks ?? 0),
-      dividendsPending: data?.dividendsPending ?? 0,
-      loyaltyStamps: data?.loyaltyStamps ?? data?.discountUses ?? 0,
-      payItForwardContrib: data?.payItForwardContrib ?? 0,
-      communityContrib: data?.communityContrib ?? 0,
-      discountCredits: profile?.discount_credits ?? 0,
+      freebiesLeft,
+      dividendsPending,
+      loyaltyStamps,
+      payItForwardContrib,
+      communityContrib,
+      discountCredits,
     };
     globalThis.freebiesLeft = result.freebiesLeft;
     globalThis.loyaltyStamps = result.loyaltyStamps;


### PR DESCRIPTION
## Summary
- fetch loyalty stamps and drink vouchers directly from Supabase so rewards stay in sync
- display free drink counter for any signed-in user who has vouchers, even if not on paid tier

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a737eeb52c832282038e36910dc907