### PR TITLE
feat: log stats query errors

### DIFF
--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -25,8 +25,8 @@ export async function getMyStats() {
     const [
       { data: profile },
       { data: statsData, error: statsError },
-      { count: voucherCount },
-      { data: stampRows },
+      { count: voucherCount, error: voucherError },
+      { data: stampRows, error: stampError },
     ] = await Promise.all([
       supabase
         .from('profiles')
@@ -45,13 +45,20 @@ export async function getMyStats() {
         .eq('user_id', session.user.id),
     ]);
 
+    if (voucherError) {
+      console.error('Error fetching drink_vouchers:', voucherError);
+    }
+    if (stampError) {
+      console.error('Error fetching loyalty_stamps:', stampError);
+    }
 
     const edgeStats = statsError ? {} : statsData || {};
-    const freebiesLeft = (profile?.free_drinks ?? 0) + (voucherCount ?? 0);
+    const freebiesLeft =
+      (profile?.free_drinks ?? 0) + (voucherError ? 0 : (voucherCount ?? 0));
     const dividendsPending = edgeStats.dividendsPending ?? 0;
     const loyaltyStamps =
       (edgeStats.loyaltyStamps ?? edgeStats.discountUses ?? 0) +
-      (stampRows ?? []).reduce((sum, r) => sum + (r.stamps || 0), 0);
+      (stampError ? 0 : (stampRows ?? []).reduce((sum, r) => sum + (r.stamps || 0), 0));
     const payItForwardContrib = edgeStats.payItForwardContrib ?? 0;
     const communityContrib = edgeStats.communityContrib ?? 0;
     const discountCredits = profile?.discount_credits ?? 0;


### PR DESCRIPTION
## Summary
- log drink voucher and loyalty stamp query errors instead of failing silently
- skip failed voucher or stamp queries while still returning other stats

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a827066f9c8322afe59e5ac5243ca2