### PR TITLE
Improve reward scripts with direct user lookup and profile sync

### DIFF
--- a/scripts/reset-rewards.js
+++ b/scripts/reset-rewards.js
@@ -17,13 +17,11 @@ if (!serviceKey) {
 const admin = createClient(url, serviceKey);
 
 (async () => {
-  const { data: listRes, error: listErr } = await admin.auth.admin.listUsers();
-  if (listErr) {
-    console.error('Failed to list users.');
-    process.exit(1);
-  }
-  const user = listRes?.users?.find(u => u.email?.toLowerCase() === email.toLowerCase());
-  if (!user) {
+  const {
+    data: { user },
+    error: userErr,
+  } = await admin.auth.admin.getUserByEmail(email);
+  if (userErr || !user) {
     console.error('User not found.');
     process.exit(1);
   }
@@ -31,6 +29,7 @@ const admin = createClient(url, serviceKey);
 
   await admin.from('drink_vouchers').delete().eq('user_id', userId);
   await admin.from('loyalty_stamps').delete().eq('user_id', userId);
+  await admin.from('profiles').update({ free_drinks: 0 }).eq('user_id', userId);
 
   console.log(`Reset free drinks and loyalty stamps for ${email}`);
 })();


### PR DESCRIPTION
## Summary
- look up users by email instead of scanning auth list
- sync profile `free_drinks` when granting or resetting rewards

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8271e89648322888b9c8c318ab575