### PR TITLE
Ensure vouchers show in membership QR carousel

### DIFF
--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -41,12 +41,14 @@ export default function MembershipScreen({ navigation }) {
 
   const refresh = useCallback(async () => {
     try { const m = await getMembershipSummary(); if (m) setSummary(m); } catch {}
+    let codes = [];
     try {
       const s = await getMyStats();
       setStats(s);
       globalThis.freebiesLeft = s.freebiesLeft;
       globalThis.loyaltyStamps = s.loyaltyStamps;
-      await syncVouchers(s.freebiesLeft);
+      codes = await syncVouchers(s.freebiesLeft);
+      setVouchers(codes.map(c => `ruminate:voucher:${c}`));
     } catch {}
     if (supabase) {
       try {
@@ -57,7 +59,7 @@ export default function MembershipScreen({ navigation }) {
           try {
             const qrs = await getMemberQRCodes(usr.id);
             setPayload(qrs.payload);
-            setVouchers(qrs.vouchers || []);
+            if (!codes.length) setVouchers(qrs.vouchers || []);
           } catch {}
         } else {
           setPayload('ruminate:member');


### PR DESCRIPTION
## Summary
- sync voucher codes with QR carousel when refreshing membership data
- fall back to server codes only if sync step fails

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a829ece4048322ba0e56cc1abf3b87