### PR TITLE
Sync free drink and stamp counts across screens

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -62,8 +62,12 @@ export default function HomeScreen({ navigation }) {
       try {
         const stats = await getMyStats();
         if (mounted) {
-          setFreebiesLeft(stats.freebiesLeft || 0);
-          setLoyalty({ current: stats.loyaltyStamps || 0, target: 8 });
+          const freebies = stats.freebiesLeft || 0;
+          const stamps = stats.loyaltyStamps || 0;
+          setFreebiesLeft(freebies);
+          setLoyalty({ current: stamps, target: 8 });
+          globalThis.freebiesLeft = freebies;
+          globalThis.loyaltyStamps = stamps;
         }
       } catch {}
       try { const ig = await getLatestInstagramPost(); if (mounted) setIgPost(ig); } catch {}

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -94,12 +94,6 @@ export default function MembershipScreen({ navigation }) {
   const [notice, setNotice] = useState('');
   useEffect(() => {
     if (stats.loyaltyStamps >= 8) {
-      setStats(s => {
-        const updated = { ...s, loyaltyStamps: s.loyaltyStamps - 8, freebiesLeft: s.freebiesLeft + 1 };
-        globalThis.freebiesLeft = updated.freebiesLeft;
-        globalThis.loyaltyStamps = updated.loyaltyStamps;
-        return updated;
-      });
       setNotice("You've earned a free drink!");
       const t = setTimeout(() => setNotice(''), 4000);
       return () => clearTimeout(t);
@@ -175,7 +169,7 @@ export default function MembershipScreen({ navigation }) {
               </View>
             )}
 
-            {summary.tier === 'paid' && (
+            {(summary.tier === 'paid' || stats.freebiesLeft > 0) && (
               <View style={{ marginTop: 14 }}>
                 <FreeDrinksCounter count={stats.freebiesLeft} />
               </View>


### PR DESCRIPTION
## Summary
- Show free-drink counter on Membership screen whenever user has free drinks available
- Remove client-side mutation of loyalty stamp counts and just display Supabase values
- Sync global free drink and stamp totals in Home screen after fetching stats

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8344754d083229de07e8d9e9968ea