### PR TITLE
Fix duplicate payload variable in MembershipScreen

### DIFF
--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -85,7 +85,6 @@ export default function MembershipScreen({ navigation }) {
   }, [refresh]);
   useFocusEffect(useCallback(() => { let on = true; (async()=>{ if(on) await refresh(); })(); return () => { on = false; }; }, [refresh]));
 
-  const payload = user ? `ruminate:${user.id}` : 'ruminate:member';
 
   useEffect(() => {
     setVouchers(v => {


### PR DESCRIPTION
## Summary
- remove duplicate `payload` declaration in `MembershipScreen` to resolve SyntaxError
- ensure file ends with newline

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8412947848322b3f4e4bb8fb4a528