### PR TITLE
fix: use esm for configs

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,8 +1,8 @@
-require('dotenv').config();
-const appJson = require('./app.json');
+import 'dotenv/config';
+import appJson from './app.json';
 
-module.exports = ({ config }) => {
-  const base = (config && Object.keys(config).length ? config : (appJson.expo || {}));
+export default ({ config }) => {
+  const base = config && Object.keys(config).length ? config : (appJson.expo || {});
   return {
     ...base,
     name: base.name || 'Ruminate Cafe',
@@ -11,7 +11,7 @@ module.exports = ({ config }) => {
       ...(base.extra || {}),
       SUPABASE_URL: process.env.SUPABASE_URL || 'https://eamewialuovzguldcdcf.supabase.co',
       SUPABASE_ANON_KEY:
-        process.env.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVhbWV3aWFsdW92emd1bGRjZGNmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxNjY5MjIsImV4cCI6MjA3MDc0MjkyMn0.oZy-UH7mB7NSFZZyivm3dbCtjsbOahcD2_coUNiiQNs',
+        process.env.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVhbWV3aWFsdW92eGd1bGRjZGNmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxNjY5MjIsImV4cCI6MjA3MDc0MjkyMn0.oZy-UH7mB7NSFZZyivm3dbCtjsbOahcD2_coUNiiQNs',
       FUNCTIONS_URL:
         process.env.FUNCTIONS_URL || 'https://eamewialuovzguldcdcf.functions.supabase.co',
     },

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
-module.exports = function(api) {
+export default function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
     plugins: ['react-native-reanimated/plugin'],
   };
-};
+}


### PR DESCRIPTION
## Summary
- convert `app.config.js` to ESM syntax
- convert `babel.config.js` to ESM syntax

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8a419cb088322a38bdbabec975ffe