### PR TITLE
Fix loyalty stamp display and auto-redeem on home screen

### DIFF
--- a/src/components/LoyaltyStampTile.js
+++ b/src/components/LoyaltyStampTile.js
@@ -4,7 +4,7 @@ import Svg, { Path } from 'react-native-svg';
 import { palette } from '../design/theme';
 
 export default function LoyaltyStampTile({ count = 0 }) {
-  const filled = Math.max(0, Math.min(8, count));
+  const filled = ((count % 8) + 8) % 8;
   const beans = Array.from({ length: 8 }, (_, i) => i < filled);
   const Bean = ({ filled }) => (
     <Svg width={24} height={24} viewBox="0 0 24 24" style={styles.bean}>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -14,6 +14,7 @@ import { getFundCurrent, getFundProgress } from '../services/community';
 import { getToday, getPayItForward, openInstagramProfile, getWeeklyHours, getLatestInstagramPost } from '../services/homeData';
 import { getMyStats } from '../services/stats';
 import { getCMS } from '../services/cms';
+import { redeemLoyaltyReward } from '../services/loyalty';
 import logo from '../../assets/logo.png';
 
 function ProgressBar({ value, max, tint = palette.clay, track = '#EED8C4' }) {
@@ -114,6 +115,23 @@ export default function HomeScreen({ navigation }) {
       Animated.timing(quoteOpacity, { toValue: 1, duration: 1000, useNativeDriver: true }).start();
     }
   }, [signedIn]);
+
+  useEffect(() => {
+    if (loyalty.current >= 8) {
+      (async () => {
+        try { await redeemLoyaltyReward(); } catch {}
+        try {
+          const stats = await getMyStats();
+          const freebies = stats.freebiesLeft || 0;
+          const stamps = stats.loyaltyStamps || 0;
+          setFreebiesLeft(freebies);
+          setLoyalty({ current: stamps, target: 8 });
+          globalThis.freebiesLeft = freebies;
+          globalThis.loyaltyStamps = stamps;
+        } catch {}
+      })();
+    }
+  }, [loyalty.current]);
 
   return (
     <SafeAreaView style={styles.container} edges={['left','right']}>


### PR DESCRIPTION
## Summary
- Show only earned loyalty beans using modulo logic
- Redeem loyalty rewards on the home screen once 8 stamps are reached

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aa0c29822c832294cdcc60adbe87ae