### PR TITLE
Fix loyalty stamp display and auto-redeem on home screen

### DIFF
--- a/scripts/reset-rewards.js
+++ b/scripts/reset-rewards.js
@@ -30,7 +30,7 @@ const admin = createClient(url, serviceKey);
 
   await admin.from('drink_vouchers').delete().eq('user_id', userId);
   await admin.from('loyalty_stamps').delete().eq('user_id', userId);
-  await admin.from('profiles').update({ free_drinks: 0 }).eq('user_id', userId);
+  await admin.from('profiles').upsert({ user_id: userId, free_drinks: 0 });
 
   console.log(`Reset free drinks and loyalty stamps for ${email}`);
 })();

--- a/src/components/LoyaltyStampTile.js
+++ b/src/components/LoyaltyStampTile.js
@@ -4,7 +4,7 @@ import Svg, { Path } from 'react-native-svg';
 import { palette } from '../design/theme';
 
 export default function LoyaltyStampTile({ count = 0 }) {
-  const filled = Math.max(0, Math.min(8, count));
+  const filled = ((count % 8) + 8) % 8;
   const beans = Array.from({ length: 8 }, (_, i) => i < filled);
   const Bean = ({ filled }) => (
     <Svg width={24} height={24} viewBox="0 0 24 24" style={styles.bean}>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -14,6 +14,7 @@ import { getFundCurrent, getFundProgress } from '../services/community';
 import { getToday, getPayItForward, openInstagramProfile, getWeeklyHours, getLatestInstagramPost } from '../services/homeData';
 import { getMyStats } from '../services/stats';
 import { getCMS } from '../services/cms';
+import { redeemLoyaltyReward } from '../services/loyalty';
 import logo from '../../assets/logo.png';
 
 function ProgressBar({ value, max, tint = palette.clay, track = '#EED8C4' }) {
@@ -114,6 +115,23 @@ export default function HomeScreen({ navigation }) {
       Animated.timing(quoteOpacity, { toValue: 1, duration: 1000, useNativeDriver: true }).start();
     }
   }, [signedIn]);
+
+  useEffect(() => {
+    if (loyalty.current >= 8) {
+      (async () => {
+        try { await redeemLoyaltyReward(); } catch {}
+        try {
+          const stats = await getMyStats();
+          const freebies = stats.freebiesLeft || 0;
+          const stamps = stats.loyaltyStamps || 0;
+          setFreebiesLeft(freebies);
+          setLoyalty({ current: stamps, target: 8 });
+          globalThis.freebiesLeft = freebies;
+          globalThis.loyaltyStamps = stamps;
+        } catch {}
+      })();
+    }
+  }, [loyalty.current]);
 
   return (
     <SafeAreaView style={styles.container} edges={['left','right']}>

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -25,8 +25,6 @@ export async function getMyStats() {
     const [
       { data: profile },
       { data: statsData, error: statsError },
-      { count: voucherCount, error: voucherError },
-      { data: stampRows, error: stampError },
     ] = await Promise.all([
       supabase
         .from('profiles')
@@ -34,31 +32,12 @@ export async function getMyStats() {
         .eq('user_id', session.user.id)
         .maybeSingle(),
       supabase.functions.invoke('me-stats', { body: {} }),
-        supabase
-          .from('drink_vouchers')
-          .select('id', { count: 'exact', head: true })
-          .eq('user_id', session.user.id)
-          .or('redeemed.eq.false,redeemed.is.null'),
-      supabase
-        .from('loyalty_stamps')
-        .select('stamps')
-        .eq('user_id', session.user.id),
     ]);
 
-    if (voucherError) {
-      console.error('Error fetching drink_vouchers:', voucherError);
-    }
-    if (stampError) {
-      console.error('Error fetching loyalty_stamps:', stampError);
-    }
-
     const edgeStats = statsError ? {} : statsData || {};
-    const freebiesLeft =
-      (profile?.free_drinks ?? 0) + (voucherError ? 0 : (voucherCount ?? 0));
+    const freebiesLeft = (profile?.free_drinks ?? 0) + (edgeStats.freebiesLeft ?? 0);
     const dividendsPending = edgeStats.dividendsPending ?? 0;
-    const loyaltyStamps =
-      (edgeStats.loyaltyStamps ?? edgeStats.discountUses ?? 0) +
-      (stampError ? 0 : (stampRows ?? []).reduce((sum, r) => sum + (r.stamps || 0), 0));
+    const loyaltyStamps = edgeStats.loyaltyStamps ?? edgeStats.discountUses ?? 0;
     const payItForwardContrib = edgeStats.payItForwardContrib ?? 0;
     const communityContrib = edgeStats.communityContrib ?? 0;
     const discountCredits = profile?.discount_credits ?? 0;

--- a/supabase/functions/loyalty-redeem/index.ts
+++ b/supabase/functions/loyalty-redeem/index.ts
@@ -1,0 +1,59 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+function cors() {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Access-Control-Allow-Headers": "authorization,content-type",
+  };
+}
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: cors() });
+  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: cors() });
+
+  const authHeader = req.headers.get("Authorization") ?? "";
+  const auth = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, { global: { headers: { Authorization: authHeader } } });
+  const { data: { user } } = await auth.auth.getUser();
+  if (!user) return new Response("Unauthorized", { status: 401, headers: cors() });
+
+  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const { data: stampRows } = await admin
+    .from("loyalty_stamps")
+    .select("id, stamps")
+    .eq("user_id", user.id);
+  const total = (stampRows ?? []).reduce((sum, r) => sum + (r.stamps || 0), 0);
+  if (total < 8) {
+    return new Response(JSON.stringify({ success: false }), {
+      status: 200,
+      headers: { ...cors(), "content-type": "application/json" },
+    });
+  }
+
+  const remaining = total - 8;
+  await admin.from("loyalty_stamps").delete().eq("user_id", user.id);
+  if (remaining > 0) {
+    await admin.from("loyalty_stamps").insert({ user_id: user.id, stamps: remaining });
+  }
+
+  const code = crypto.randomUUID();
+  await admin.from("drink_vouchers").insert({ user_id: user.id, code });
+
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("free_drinks")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const freeDrinks = (profile?.free_drinks ?? 0) + 1;
+  await admin.from("profiles").upsert({ user_id: user.id, free_drinks: freeDrinks });
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { ...cors(), "content-type": "application/json" },
+  });
+});


### PR DESCRIPTION
## Summary
- Show only earned loyalty beans using modulo logic
- Redeem loyalty rewards on the home screen once 8 stamps are reached
- Add Supabase function to convert 8 stamps into a voucher and reset stamps
- Avoid double-counting loyalty stamps by relying on `me-stats`
- Upsert profile record when resetting rewards

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aa0c29822c832294cdcc60adbe87ae