### PR TITLE
Normalize loyalty rewards and sync vouchers from server

### DIFF
--- a/scripts/_supabase.js
+++ b/scripts/_supabase.js
@@ -1,0 +1,33 @@
+import { createClient } from '@supabase/supabase-js';
+
+export function createAdminClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  return createClient(url, key);
+}
+
+export async function findUserIdByEmail(supabase, email) {
+  const { data, error } = await supabase
+    .from('users', { schema: 'auth' })
+    .select('id,email')
+    .ilike('email', email)
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  if (!data?.id) throw new Error('User not found');
+  return data.id;
+}
+
+export async function findUserIdByEmailFallback(supabase, email) {
+  let page = 1;
+  for (;;) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage: 1000 });
+    if (error) throw error;
+    const u = data?.users?.find(x => x.email?.toLowerCase() === email.toLowerCase());
+    if (u) return u.id;
+    if (!data?.users?.length) break;
+    page++;
+  }
+  throw new Error('User not found');
+}

--- a/scripts/reset-rewards.js
+++ b/scripts/reset-rewards.js
@@ -1,31 +1,27 @@
 #!/usr/bin/env node
-import { createClient } from '@supabase/supabase-js';
+import { createAdminClient, findUserIdByEmail } from './_supabase.js';
 
-const [email] = process.argv.slice(2);
+const email = process.argv[2];
 if (!email) {
-  console.error('Usage: node reset-rewards.js <email>');
+  console.error('Usage: node scripts/reset-rewards.js <email>');
   process.exit(1);
 }
 
-const url = process.env.SUPABASE_URL || process.env.EXPO_PUBLIC_SUPABASE_URL;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY;
-if (!url || !serviceKey) {
-  console.error('Missing Supabase environment variables.');
-  process.exit(1);
-}
+const supabase = createAdminClient();
 
-const supabase = createClient(url, serviceKey);
+const uid = await findUserIdByEmail(supabase, email);
 
-try {
-  const { data: { user } } = await supabase.auth.admin.getUserByEmail(email);
-  if (!user) throw new Error('User not found');
-  const userId = user.id;
+let { error: e1 } = await supabase
+  .from('loyalty_stamps')
+  .delete()
+  .eq('user_id', uid);
+if (e1) throw e1;
 
-  await supabase.from('loyalty_stamps').delete().eq('user_id', userId);
-  await supabase.from('drink_vouchers').delete().eq('user_id', userId).eq('redeemed', false);
+let { error: e2 } = await supabase
+  .from('drink_vouchers')
+  .delete()
+  .eq('user_id', uid)
+  .eq('redeemed', false);
+if (e2) throw e2;
 
-  console.log(JSON.stringify({ stamps: 0, vouchersUnredeemed: 0 }, null, 2));
-} catch (err) {
-  console.error(err.message);
-  process.exit(1);
-}
+console.log(`Reset free drinks and loyalty stamps for ${email}`);

--- a/src/services/vouchers.js
+++ b/src/services/vouchers.js
@@ -1,12 +1,12 @@
 import { supabase, hasSupabase } from '../lib/supabase';
 
-export async function syncVouchers(freebiesLeft) {
+export async function syncVouchers() {
   if (!hasSupabase || !supabase) {
     return [];
   }
   try {
-    const { data } = await supabase.functions.invoke('vouchers-sync', { body: { freebiesLeft } });
-    return data?.codes ?? [];
+    const { data } = await supabase.functions.invoke('vouchers-sync', { body: {} });
+    return data?.vouchers ?? [];
   } catch {
     return [];
   }

--- a/supabase/functions/_shared/rewards.ts
+++ b/supabase/functions/_shared/rewards.ts
@@ -1,0 +1,46 @@
+import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+export async function normalizeRewards(admin: SupabaseClient, userId: string) {
+  const { count: totalStamps = 0 } = await admin
+    .from("loyalty_stamps")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", userId);
+
+  let { data: vouchers, error } = await admin
+    .from("drink_vouchers")
+    .select("code, redeemed, created_at")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+
+  let vouchersTotal = vouchers?.length ?? 0;
+  let vouchersUnredeemed = vouchers?.filter(v => !v.redeemed).length ?? 0;
+
+  const shouldExist = Math.floor((totalStamps || 0) / 8);
+  const toMint = Math.max(0, shouldExist - vouchersTotal);
+
+  if (toMint > 0) {
+    const inserts = Array.from({ length: toMint }, () => ({
+      user_id: userId,
+      code: crypto.randomUUID(),
+    }));
+    await admin.from("drink_vouchers").insert(inserts);
+    const { data: refreshed, error: refErr } = await admin
+      .from("drink_vouchers")
+      .select("code, redeemed, created_at")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false });
+    if (refErr) throw refErr;
+    vouchers = refreshed ?? [];
+    vouchersTotal = vouchers.length;
+    vouchersUnredeemed = vouchers.filter(v => !v.redeemed).length;
+  }
+
+  const remainder = (totalStamps || 0) - shouldExist * 8;
+
+  return {
+    loyaltyStamps: remainder,
+    freebiesLeft: vouchersUnredeemed,
+    vouchers: vouchers?.map(v => ({ code: v.code, redeemed: v.redeemed })) ?? [],
+  };
+}

--- a/supabase/functions/me-stats/index.ts
+++ b/supabase/functions/me-stats/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { normalizeRewards } from "../_shared/rewards.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
@@ -23,42 +24,16 @@ serve(async (req: Request) => {
   if (!user) return new Response("Unauthorized", { status: 401, headers: cors() });
 
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
-
-  const { count: totalStamps = 0 } = await admin
-    .from("loyalty_stamps")
-    .select("id", { count: "exact", head: true })
-    .eq("user_id", user.id);
-
-  const { count: vouchersTotal = 0 } = await admin
-    .from("drink_vouchers")
-    .select("id", { count: "exact", head: true })
-    .eq("user_id", user.id);
-
-  const { count: vouchersUnredeemed = 0 } = await admin
-    .from("drink_vouchers")
-    .select("id", { count: "exact", head: true })
-    .eq("user_id", user.id)
-    .eq("redeemed", false);
-
-  const shouldExist = Math.floor(totalStamps / 8);
-  const toMint = Math.max(0, shouldExist - vouchersTotal);
-  if (toMint > 0) {
-    const inserts = Array.from({ length: toMint }, () => ({
-      user_id: user.id,
-      code: crypto.randomUUID(),
-    }));
-    await admin.from("drink_vouchers").upsert(inserts, { onConflict: "code" });
-  }
-
-  const remainder = totalStamps - shouldExist * 8;
+  const stats = await normalizeRewards(admin, user.id);
 
   return new Response(
     JSON.stringify({
-      freebiesLeft: (vouchersUnredeemed ?? 0) + toMint,
+      freebiesLeft: stats.freebiesLeft,
       dividendsPending: 0,
-      loyaltyStamps: remainder,
+      loyaltyStamps: stats.loyaltyStamps,
       payItForwardContrib: 0,
       communityContrib: 0,
+      vouchers: stats.vouchers,
     }),
     { headers: { ...cors(), "content-type": "application/json" } }
   );

--- a/supabase/functions/vouchers-sync/index.ts
+++ b/supabase/functions/vouchers-sync/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { normalizeRewards } from "../_shared/rewards.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
@@ -17,30 +18,15 @@ serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: cors() });
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: cors() });
 
-  let body: any = {};
-  try { body = await req.json(); } catch {}
-  const desired = Math.max(0, parseInt(body?.freebiesLeft) || 0);
-
   const authHeader = req.headers.get("Authorization") ?? "";
   const auth = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, { global: { headers: { Authorization: authHeader } } });
   const { data: { user } } = await auth.auth.getUser();
   if (!user) return new Response("Unauthorized", { status: 401, headers: cors() });
-
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
-  const { data: existing } = await admin
-    .from("drink_vouchers")
-    .select("code")
-    .eq("user_id", user.id)
-    .eq("redeemed", false);
-  const codes = existing?.map(r => r.code) ?? [];
+  const stats = await normalizeRewards(admin, user.id);
 
-  if (codes.length < desired) {
-    const toCreate = desired - codes.length;
-    const newCodes = Array.from({ length: toCreate }, () => crypto.randomUUID());
-    const inserts = newCodes.map(code => ({ code, user_id: user.id }));
-    await admin.from("drink_vouchers").insert(inserts);
-    codes.push(...newCodes);
-  }
-
-  return new Response(JSON.stringify({ codes }), { headers: { ...cors(), "content-type": "application/json" } });
+  return new Response(
+    JSON.stringify({ vouchers: stats.vouchers }),
+    { headers: { ...cors(), "content-type": "application/json" } }
+  );
 });


### PR DESCRIPTION
## Summary
- centralize rewards normalization in a shared helper and use it in `me-stats` and `vouchers-sync`
- rewrite admin reward scripts with auth schema email lookup and ESM helpers
- fetch voucher codes from the server in `MembershipScreen` and render stamp remainder only

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa16e50ffc8322950be9a47819ae93