### PR TITLE
fix: normalize loyalty rollover and show server vouchers

### DIFF
--- a/src/components/LoyaltyStampTile.js
+++ b/src/components/LoyaltyStampTile.js
@@ -4,7 +4,11 @@ import Svg, { Path } from 'react-native-svg';
 import { palette } from '../design/theme';
 
 export default function LoyaltyStampTile({ count = 0 }) {
-  const filled = Math.max(0, Math.min(7, count));
+  const normalized = Number.isFinite(count) ? count : 0;
+  if (normalized < 0 || normalized > 7) {
+    console.warn('[LOYALTY_TILE] count out of range, got', count, '— applying % 8 fallback');
+  }
+  const filled = ((normalized % 8) + 8) % 8;
   const beans = Array.from({ length: 8 }, (_, i) => i < filled);
   const Bean = ({ filled }) => (
     <Svg width={24} height={24} viewBox="0 0 24 24" style={styles.bean}>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -59,7 +59,8 @@ export default function HomeScreen({ navigation }) {
       try { const t = await getToday(); if (mounted) setToday(t); } catch {}
       try { const s = await getPIFStats(); if (mounted) setPif(s); } catch {}
       try {
-        const stats = await getMyStats();
+        const { data: { session } } = await supabase.auth.getSession();
+        const stats = await getMyStats(session?.access_token);
         if (mounted) {
           const freebies = stats.freebiesLeft || 0;
           const stamps = stats.loyaltyStamps || 0;

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -1,69 +1,16 @@
-import { supabase, hasSupabase } from '../lib/supabase';
-
-export async function getMyStats() {
-  if (!hasSupabase || !supabase) {
-    return {
-      freebiesLeft: 0,
-      dividendsPending: 0,
-      loyaltyStamps: 0,
-      payItForwardContrib: 0,
-      communityContrib: 0,
-    };
+export async function getMyStats(token) {
+  const base = process.env.EXPO_PUBLIC_FUNCTIONS_URL || (process.env.EXPO_PUBLIC_SUPABASE_URL + '/functions/v1');
+  const r = await fetch(`${base}/me-stats`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token || ''}` },
+    body: JSON.stringify({}),
+  });
+  const json = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(json?.error || `me-stats ${r.status}`);
+  const { loyaltyStamps, freebiesLeft, vouchers } = json;
+  if (![loyaltyStamps, freebiesLeft].every(n => Number.isFinite(n)) || !Array.isArray(vouchers)) {
+    throw new Error('Invalid me-stats payload');
   }
-
-  try {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) {
-      return {
-        freebiesLeft: 0,
-        dividendsPending: 0,
-        loyaltyStamps: 0,
-        payItForwardContrib: 0,
-        communityContrib: 0,
-      };
-    }
-    const [
-      { data: profile },
-      { data: statsData, error: statsError },
-    ] = await Promise.all([
-      supabase
-        .from('profiles')
-        .select('discount_credits')
-        .eq('user_id', session.user.id)
-        .maybeSingle(),
-      supabase.functions.invoke('me-stats', { body: {} }),
-    ]);
-
-    const edgeStats = statsError ? {} : statsData || {};
-    const freebiesLeft = edgeStats.freebiesLeft ?? 0;
-    const dividendsPending = edgeStats.dividendsPending ?? 0;
-    const loyaltyStamps = edgeStats.loyaltyStamps ?? edgeStats.discountUses ?? 0;
-    const payItForwardContrib = edgeStats.payItForwardContrib ?? 0;
-    const communityContrib = edgeStats.communityContrib ?? 0;
-    const discountCredits = profile?.discount_credits ?? 0;
-
-    const result = {
-      freebiesLeft,
-      dividendsPending,
-      loyaltyStamps,
-      payItForwardContrib,
-      communityContrib,
-      discountCredits,
-    };
-    globalThis.freebiesLeft = result.freebiesLeft;
-    globalThis.loyaltyStamps = result.loyaltyStamps;
-    return result;
-  } catch {
-    const result = {
-      freebiesLeft: 0,
-      dividendsPending: 0,
-      loyaltyStamps: 0,
-      payItForwardContrib: 0,
-      communityContrib: 0,
-      discountCredits: 0,
-    };
-    globalThis.freebiesLeft = result.freebiesLeft;
-    globalThis.loyaltyStamps = result.loyaltyStamps;
-    return result;
-  }
+  return { loyaltyStamps, freebiesLeft, vouchers };
 }
+


### PR DESCRIPTION
## Summary
- normalize rewards in `me-stats` to mint vouchers and return remainder and codes
- fetch stats with vouchers on client and render them in pager view
- guard loyalty tile rendering count modulo 8

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: errors in unrelated backup/scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3678d7ac8322992f17306b22ecbd