### PR TITLE
fix: robust admin scripts and membership vouchers

### DIFF
--- a/scripts/grant-rewards.js
+++ b/scripts/grant-rewards.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
 import crypto from 'node:crypto';
-import { createAdminClient, findUserIdByEmail } from './_supabase.js';
 
 const [,, email, freeDrinksArg, stampsArg] = process.argv;
 if (!email) {
@@ -8,41 +9,54 @@ if (!email) {
   process.exit(1);
 }
 
-const freeDrinks = Number(freeDrinksArg || 0);
-const addStamps = Number(stampsArg || 0);
+const drinks = Number(freeDrinksArg || 0);
+const stamps = Number(stampsArg || 0);
 
-const supabase = createAdminClient();
-const uid = await findUserIdByEmail(supabase, email);
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+const admin = createClient(url, key, { auth: { persistSession: false } });
 
-if (addStamps > 0) {
-  const rows = Array.from({ length: addStamps }, () => ({ user_id: uid, stamps: 1 }));
-  const { error } = await supabase.from('loyalty_stamps').insert(rows);
+async function getUserByEmailOrList(email) {
+  const hasGetByEmail =
+    admin?.auth?.admin && typeof admin.auth.admin.getUserByEmail === 'function';
+
+  if (hasGetByEmail) {
+    const { data, error } = await admin.auth.admin.getUserByEmail(email);
+    if (error) throw error;
+    if (!data?.user) throw new Error(`User not found for ${email}`);
+    return data.user;
+  }
+
+  let page = 1;
+  for (;;) {
+    const { data, error } = await admin.auth.admin.listUsers({ page, perPage: 1000 });
+    if (error) throw error;
+    const hit = data?.users?.find(u => u.email?.toLowerCase() === email.toLowerCase());
+    if (hit) return hit;
+    if (!data?.users?.length) break;
+    page++;
+  }
+  throw new Error(`User not found for ${email}`);
+}
+
+const user = await getUserByEmailOrList(email);
+
+if (stamps > 0) {
+  const rows = Array.from({ length: stamps }, () => ({ user_id: user.id }));
+  const { error } = await admin.from('loyalty_stamps').insert(rows);
   if (error) throw error;
 }
 
-if (freeDrinks > 0) {
-  const rows = Array.from({ length: freeDrinks }, () => ({
-    user_id: uid,
-    code: crypto.randomUUID()
+if (drinks > 0) {
+  const rows = Array.from({ length: drinks }, () => ({
+    user_id: user.id,
+    code: crypto.randomUUID(),
+    redeemed: false,
   }));
-  const { error } = await supabase
-    .from('drink_vouchers')
-    .insert(rows, { count: 'exact' });
+  const { error } = await admin.from('drink_vouchers').insert(rows);
   if (error) throw error;
 }
 
-const functionsUrl = process.env.FUNCTIONS_URL || process.env.EXPO_PUBLIC_FUNCTIONS_URL;
-const svcKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+console.log(`[SCRIPT] Granted ${drinks} free drinks and ${stamps} loyalty stamps to ${email}`);
 
-if (functionsUrl) {
-  await fetch(`${functionsUrl}/me-stats`, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${svcKey}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ userId: uid, normalize: true })
-  }).catch(() => {});
-}
-
-console.log(`Granted ${freeDrinks} free drinks and ${addStamps} loyalty stamps to ${email}`);

--- a/scripts/reset-rewards.js
+++ b/scripts/reset-rewards.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { createAdminClient, findUserIdByEmail } from './_supabase.js';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
 
 const email = process.argv[2];
 if (!email) {
@@ -7,21 +8,47 @@ if (!email) {
   process.exit(1);
 }
 
-const supabase = createAdminClient();
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+const admin = createClient(url, key, { auth: { persistSession: false } });
 
-const uid = await findUserIdByEmail(supabase, email);
+async function getUserByEmailOrList(email) {
+  const hasGetByEmail =
+    admin?.auth?.admin && typeof admin.auth.admin.getUserByEmail === 'function';
 
-let { error: e1 } = await supabase
+  if (hasGetByEmail) {
+    const { data, error } = await admin.auth.admin.getUserByEmail(email);
+    if (error) throw error;
+    if (!data?.user) throw new Error(`User not found for ${email}`);
+    return data.user;
+  }
+
+  let page = 1;
+  for (;;) {
+    const { data, error } = await admin.auth.admin.listUsers({ page, perPage: 1000 });
+    if (error) throw error;
+    const hit = data?.users?.find(u => u.email?.toLowerCase() === email.toLowerCase());
+    if (hit) return hit;
+    if (!data?.users?.length) break;
+    page++;
+  }
+  throw new Error(`User not found for ${email}`);
+}
+
+const user = await getUserByEmailOrList(email);
+
+const { error: e1, count: sCount } = await admin
   .from('loyalty_stamps')
-  .delete()
-  .eq('user_id', uid);
+  .delete({ count: 'exact' })
+  .eq('user_id', user.id);
 if (e1) throw e1;
 
-let { error: e2 } = await supabase
+const { error: e2, count: vCount } = await admin
   .from('drink_vouchers')
-  .delete()
-  .eq('user_id', uid)
-  .eq('redeemed', false);
+  .delete({ count: 'exact' })
+  .eq('user_id', user.id);
 if (e2) throw e2;
 
-console.log(`Reset free drinks and loyalty stamps for ${email}`);
+console.log(`[SCRIPT] Reset free drinks and loyalty stamps for ${email} (removed ${vCount || 0} vouchers, ${sCount || 0} stamps)`);
+

--- a/src/components/LoyaltyStampTile.js
+++ b/src/components/LoyaltyStampTile.js
@@ -4,7 +4,11 @@ import Svg, { Path } from 'react-native-svg';
 import { palette } from '../design/theme';
 
 export default function LoyaltyStampTile({ count = 0 }) {
-  const filled = Math.max(0, Math.min(7, count));
+  const normalized = Number.isFinite(count) ? count : 0;
+  if (normalized < 0 || normalized > 7) {
+    console.warn('[LOYALTY_TILE] count out of range, got', count, '— applying % 8 fallback');
+  }
+  const filled = ((normalized % 8) + 8) % 8;
   const beans = Array.from({ length: 8 }, (_, i) => i < filled);
   const Bean = ({ filled }) => (
     <Svg width={24} height={24} viewBox="0 0 24 24" style={styles.bean}>

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -59,7 +59,8 @@ export default function HomeScreen({ navigation }) {
       try { const t = await getToday(); if (mounted) setToday(t); } catch {}
       try { const s = await getPIFStats(); if (mounted) setPif(s); } catch {}
       try {
-        const stats = await getMyStats();
+        const { data: { session } } = await supabase.auth.getSession();
+        const stats = await getMyStats(session?.access_token);
         if (mounted) {
           const freebies = stats.freebiesLeft || 0;
           const stamps = stats.loyaltyStamps || 0;

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView, View, Text, StyleSheet, Share, Pressable, Alert } from 'react-native';
 import * as Sharing from 'expo-sharing';
@@ -6,6 +6,7 @@ import * as FileSystem from 'expo-file-system';
 import membershipPassBase64 from '../../assets/membershipPassBase64';
 import { useFocusEffect } from '@react-navigation/native';
 import QRCode from 'react-native-qrcode-svg';
+import PagerView from 'react-native-pager-view';
 import { palette } from '../design/theme';
 import { supabase } from '../lib/supabase';
 import { getMembershipSummary } from '../services/membership';
@@ -30,31 +31,27 @@ export default function MembershipScreen({ navigation }) {
   const insets = useSafeAreaInsets();
   const [summary, setSummary] = useState({ signedIn: false, tier: 'free', status: 'none', next_billing_at: null });
   const [pifSelfCents, setPifSelfCents] = useState(0);
-  const [stats, setStats] = useState({ freebiesLeft: 0, dividendsPending: 0, loyaltyStamps: 0, payItForwardContrib: 0, communityContrib: 0 });
+  const [stats, setStats] = useState({
+    loyaltyStamps: globalThis.loyaltyStamps ?? 0,
+    freebiesLeft: globalThis.freebiesLeft ?? 0,
+  });
   const [vouchers, setVouchers] = useState([]);
   const [page, setPage] = useState(0);
-  const [carouselWidth, setCarouselWidth] = useState(0); // track width of carousel for QR/voucher cards
   const [user, setUser] = useState(null);
   const [session, setSession] = useState(null);
 
   const memberPayload = user ? `ruminate:${user.id}` : 'ruminate:member';
-  const pages = useMemo(() => [memberPayload, ...vouchers], [memberPayload, vouchers]);
-  const totalPages = pages.length;
-  const FUNCTIONS_URL = process.env.EXPO_PUBLIC_FUNCTIONS_URL;
+  const totalPages = 1 + vouchers.length;
 
   const refresh = useCallback(async () => {
     try { const m = await getMembershipSummary(); if (m) setSummary(m); } catch {}
-    try {
-      const s = await getMyStats();
-      setStats(s);
-      globalThis.freebiesLeft = s.freebiesLeft;
-      globalThis.loyaltyStamps = s.loyaltyStamps;
-    } catch {}
+    let token = '';
     if (supabase) {
       try {
         const { data: { session: sess } } = await supabase.auth.getSession();
         setSession(sess);
         setUser(sess?.user || null);
+        token = sess?.access_token || '';
       } catch {
         setSession(null);
         setUser(null);
@@ -63,41 +60,20 @@ export default function MembershipScreen({ navigation }) {
       setSession(null);
       setUser(null);
     }
+    try {
+      const s = await getMyStats(token);
+      if (s.loyaltyStamps < 0 || s.loyaltyStamps > 7) {
+        console.warn('[MEMBERSHIP] loyaltyStamps out of range', s.loyaltyStamps);
+      }
+      setStats({ loyaltyStamps: s.loyaltyStamps, freebiesLeft: s.freebiesLeft });
+      setVouchers(Array.from(new Set((s.vouchers || []).filter(Boolean))));
+      globalThis.freebiesLeft = s.freebiesLeft;
+      globalThis.loyaltyStamps = s.loyaltyStamps;
+    } catch {}
   }, []);
 
 
-  useEffect(() => {
-    setStats(prev => ({
-      ...prev,
-      freebiesLeft: globalThis.freebiesLeft ?? prev.freebiesLeft,
-      loyaltyStamps: globalThis.loyaltyStamps ?? prev.loyaltyStamps,
-    }));
-    refresh();
-  }, [refresh]);
-
-  useEffect(() => {
-    let on = true;
-    (async () => {
-      if (!session?.access_token || !FUNCTIONS_URL) {
-        if (on) setVouchers([]);
-        return;
-      }
-      try {
-        const res = await fetch(`${FUNCTIONS_URL}/vouchers-sync`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${session.access_token}` },
-        });
-        const json = await res.json();
-        const codes = (json?.vouchers || [])
-          .filter(v => v && v.code && !v.redeemed)
-          .map(v => v.code);
-        if (on) setVouchers(codes);
-      } catch {
-        if (on) setVouchers([]);
-      }
-    })();
-    return () => { on = false; };
-  }, [session?.access_token, stats.freebiesLeft, FUNCTIONS_URL]);
+  useEffect(() => { refresh(); }, [refresh]);
   useFocusEffect(useCallback(() => { let on = true; (async()=>{ if(on) await refresh(); })(); return () => { on = false; }; }, [refresh]));
 
   useEffect(()=>{ 
@@ -115,11 +91,11 @@ export default function MembershipScreen({ navigation }) {
   }, [user, summary]);
 
   const [notice, setNotice] = useState('');
-  const prevFreebies = useRef(globalThis.lastFreebiesLeft ?? stats.freebiesLeft);
+  const prevFreebies = useRef(globalThis.lastFreebiesLeft ?? 0);
 
   useEffect(() => {
     const prev = prevFreebies.current;
-    const curr = stats.freebiesLeft;
+    const curr = stats?.freebiesLeft ?? 0;
     if (curr - prev === 1) {
       Alert.alert('Free drink earned', 'A free drink voucher has been added to your account.');
       setNotice("You've earned a free drink!");
@@ -131,7 +107,7 @@ export default function MembershipScreen({ navigation }) {
     prevFreebies.current = curr;
     globalThis.lastFreebiesLeft = curr;
     if (curr === 0) setNotice('');
-  }, [stats.freebiesLeft]);
+  }, [stats?.freebiesLeft]);
 
   const handleAddToWallet = useCallback(async () => {
     try {
@@ -149,66 +125,47 @@ export default function MembershipScreen({ navigation }) {
       <View style={[styles.header, { paddingTop: insets.top }]}><Text style={styles.headerTitle}>Membership</Text></View>
       <ScrollView contentContainerStyle={styles.content}>
         <Text style={styles.title}>Membership</Text>
-        {notice && stats.freebiesLeft > 0 ? <Text style={styles.notice}>{notice}</Text> : null}
+        {notice && (stats?.freebiesLeft ?? 0) > 0 ? <Text style={styles.notice}>{notice}</Text> : null}
 
         {summary.signedIn ? (
           <>
 
-            <View style={{ marginTop: 14 }} onLayout={(e) => setCarouselWidth(e.nativeEvent.layout.width)}>
-              <ScrollView
-                horizontal
-                pagingEnabled
-                showsHorizontalScrollIndicator={false}
-                style={styles.carousel}
-                onMomentumScrollEnd={(e) => {
-                  const { contentOffset, layoutMeasurement } = e.nativeEvent;
-                  const index = Math.round(contentOffset.x / layoutMeasurement.width);
-                  setPage(index);
-                }}
+            <View style={{ marginTop: 14 }}>
+              <PagerView
+                style={{ height: 440, width: '100%' }}
+                initialPage={0}
+                key={`pv-${user?.id}-${vouchers.length}`}
+                onPageSelected={e => setPage(e.nativeEvent.position)}
               >
-                {pages.map((code, idx) => (
-                  <View
-                    key={idx === 0 ? 'member' : code}
-                    style={[
-                      styles.card,
-                      styles.qrCard,
-                      idx > 0 && styles.voucherCard,
-                      { width: carouselWidth },
-                    ]}
-                  >
-                    <Text
-                      style={[
-                        styles.cardTitle,
-                        idx > 0 && styles.voucherTitle,
-                      ]}
-                    >
-                      {idx === 0 ? 'Your QR' : 'Drink voucher'}
-                    </Text>
+                <View key="member" style={[styles.card, styles.qrCard]}>
+                  <Text style={styles.cardTitle}>Your QR</Text>
+                  <View style={styles.qrWrap}>
+                    <QRCode value={memberPayload} size={180} />
+                  </View>
+                  <Text style={styles.mutedSmall}>
+                    Show at the counter to redeem perks and stamps.
+                  </Text>
+                  <View style={{ marginTop: 12 }}>
+                    <GlowingGlassButton
+                      text="Add to Wallet"
+                      variant="dark"
+                      onPress={handleAddToWallet}
+                    />
+                  </View>
+                </View>
+
+                {vouchers.map(code => (
+                  <View key={code} style={[styles.card, styles.qrCard, styles.voucherCard]}>
+                    <Text style={[styles.cardTitle, styles.voucherTitle]}>Drink voucher</Text>
                     <View style={styles.qrWrap}>
                       <QRCode value={code} size={180} />
                     </View>
-                    <Text
-                      style={[
-                        styles.mutedSmall,
-                        idx > 0 && styles.voucherText,
-                      ]}
-                    >
-                      {idx === 0
-                        ? 'Show at the counter to redeem perks and stamps.'
-                        : 'Show at the counter to redeem.'}
+                    <Text style={[styles.mutedSmall, styles.voucherText]}>
+                      Show at the counter to redeem.
                     </Text>
-                    {idx === 0 && (
-                      <View style={{ marginTop: 12 }}>
-                        <GlowingGlassButton
-                          text="Add to Wallet"
-                          variant="dark"
-                          onPress={handleAddToWallet}
-                        />
-                      </View>
-                    )}
                   </View>
                 ))}
-              </ScrollView>
+              </PagerView>
               {totalPages > 1 && (
                 <>
                   <Text style={styles.swipePrompt}>Swipe to see your drink vouchers</Text>
@@ -224,19 +181,19 @@ export default function MembershipScreen({ navigation }) {
               )}
             </View>
 
-            {(summary.tier === 'paid' || stats.freebiesLeft > 0) && (
+            {(summary.tier === 'paid' || (stats?.freebiesLeft ?? 0) > 0) && (
               <View style={{ marginTop: 14 }}>
-                <FreeDrinksCounter count={stats.freebiesLeft} />
+                <FreeDrinksCounter count={stats?.freebiesLeft ?? 0} />
               </View>
             )}
 
             <View style={{ marginTop: 14 }}>
-              <LoyaltyStampTile count={stats.loyaltyStamps} />
+              <LoyaltyStampTile count={stats?.loyaltyStamps ?? 0} />
             </View>
 
             {summary.tier === 'paid' ? (
               <View style={styles.gridRow}>
-                <Stat label="Dividends pending" value={Number(stats.dividendsPending).toFixed(2)} prefix="£" />
+                <Stat label="Dividends pending" value={Number(stats?.dividendsPending || 0).toFixed(2)} prefix="£" />
                 <Stat label="Pay-it-forward" value={(pifSelfCents / 100).toFixed(2)} prefix="£" />
               </View>
             ) : (
@@ -350,7 +307,6 @@ const styles = StyleSheet.create({
   notice: { backgroundColor: palette.paper, borderColor: palette.border, borderWidth: 1, borderRadius: 10, padding: 10, marginTop: 12, textAlign: 'center', color: palette.clay, fontFamily: 'Fraunces_700Bold' },
 
   qrWrap: { alignItems: 'center', justifyContent: 'center', paddingVertical: 12, height: 260 },
-  carousel: { height: 420, width: '100%' },
   qrCard: { marginTop: 0, flex: 1 },
   voucherCard: { backgroundColor: palette.coffee, borderColor: palette.coffee },
   voucherTitle: { color: palette.cream },

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -1,69 +1,16 @@
-import { supabase, hasSupabase } from '../lib/supabase';
-
-export async function getMyStats() {
-  if (!hasSupabase || !supabase) {
-    return {
-      freebiesLeft: 0,
-      dividendsPending: 0,
-      loyaltyStamps: 0,
-      payItForwardContrib: 0,
-      communityContrib: 0,
-    };
+export async function getMyStats(token) {
+  const base = process.env.EXPO_PUBLIC_FUNCTIONS_URL || (process.env.EXPO_PUBLIC_SUPABASE_URL + '/functions/v1');
+  const r = await fetch(`${base}/me-stats`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token || ''}` },
+    body: JSON.stringify({}),
+  });
+  const json = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error(json?.error || `me-stats ${r.status}`);
+  const { loyaltyStamps, freebiesLeft, vouchers } = json;
+  if (![loyaltyStamps, freebiesLeft].every(n => Number.isFinite(n)) || !Array.isArray(vouchers)) {
+    throw new Error('Invalid me-stats payload');
   }
-
-  try {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.user) {
-      return {
-        freebiesLeft: 0,
-        dividendsPending: 0,
-        loyaltyStamps: 0,
-        payItForwardContrib: 0,
-        communityContrib: 0,
-      };
-    }
-    const [
-      { data: profile },
-      { data: statsData, error: statsError },
-    ] = await Promise.all([
-      supabase
-        .from('profiles')
-        .select('discount_credits')
-        .eq('user_id', session.user.id)
-        .maybeSingle(),
-      supabase.functions.invoke('me-stats', { body: {} }),
-    ]);
-
-    const edgeStats = statsError ? {} : statsData || {};
-    const freebiesLeft = edgeStats.freebiesLeft ?? 0;
-    const dividendsPending = edgeStats.dividendsPending ?? 0;
-    const loyaltyStamps = edgeStats.loyaltyStamps ?? edgeStats.discountUses ?? 0;
-    const payItForwardContrib = edgeStats.payItForwardContrib ?? 0;
-    const communityContrib = edgeStats.communityContrib ?? 0;
-    const discountCredits = profile?.discount_credits ?? 0;
-
-    const result = {
-      freebiesLeft,
-      dividendsPending,
-      loyaltyStamps,
-      payItForwardContrib,
-      communityContrib,
-      discountCredits,
-    };
-    globalThis.freebiesLeft = result.freebiesLeft;
-    globalThis.loyaltyStamps = result.loyaltyStamps;
-    return result;
-  } catch {
-    const result = {
-      freebiesLeft: 0,
-      dividendsPending: 0,
-      loyaltyStamps: 0,
-      payItForwardContrib: 0,
-      communityContrib: 0,
-      discountCredits: 0,
-    };
-    globalThis.freebiesLeft = result.freebiesLeft;
-    globalThis.loyaltyStamps = result.loyaltyStamps;
-    return result;
-  }
+  return { loyaltyStamps, freebiesLeft, vouchers };
 }
+

--- a/supabase/functions/me-stats/index.ts
+++ b/supabase/functions/me-stats/index.ts
@@ -25,14 +25,12 @@ serve(async (req: Request) => {
 
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const stats = await normalizeRewards(admin, user.id);
+  console.log("[ME_STATS]", stats);
 
   return new Response(
     JSON.stringify({
-      freebiesLeft: stats.freebiesLeft,
-      dividendsPending: 0,
       loyaltyStamps: stats.loyaltyStamps,
-      payItForwardContrib: 0,
-      communityContrib: 0,
+      freebiesLeft: stats.freebiesLeft,
       vouchers: stats.vouchers,
     }),
     { headers: { ...cors(), "content-type": "application/json" } }


### PR DESCRIPTION
## Summary
- harden admin reward scripts with service-role client, fallback user lookup, and explicit inserts
- ensure me-stats only returns server remainder and voucher codes
- refresh membership screen with server stats and show member QR plus voucher pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: errors in backup/scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3678d7ac8322992f17306b22ecbd