### PR TITLE
feat(rewards): sync client stats with server

### DIFF
--- a/src/components/FreeDrinksCounter.js
+++ b/src/components/FreeDrinksCounter.js
@@ -6,8 +6,7 @@ import { palette } from '../design/theme';
 
 export default function FreeDrinksCounter({ count = 0 }) {
   const limit = 3;
-  const remaining = Math.max(0, Math.min(limit, count));
-  const ratio = remaining / limit;
+  const ratio = Math.max(0, Math.min(1, count / limit));
   const size = 64;
   const radius = 28;
   const circumference = 2 * Math.PI * radius;

--- a/src/components/LoyaltyStampTile.js
+++ b/src/components/LoyaltyStampTile.js
@@ -4,12 +4,7 @@ import Svg, { Path } from 'react-native-svg';
 import { palette } from '../design/theme';
 
 export default function LoyaltyStampTile({ count = 0 }) {
-  const normalized = Number.isFinite(count) ? count : 0;
-  if (normalized < 0 || normalized > 7) {
-    console.warn('[LOYALTY_TILE] count out of range, got', count, '— applying % 8 fallback');
-  }
-  const filled = ((normalized % 8) + 8) % 8;
-  const beans = Array.from({ length: 8 }, (_, i) => i < filled);
+  const beans = Array.from({ length: 8 }, (_, i) => i < count);
   const Bean = ({ filled }) => (
     <Svg width={24} height={24} viewBox="0 0 24 24" style={styles.bean}>
       <Path

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -42,16 +42,13 @@ export default function HomeScreen({ navigation }) {
   const [fund, setFund] = useState({ total_cents: 0, goal_cents: 0 });
   const [today, setToday] = useState({ openNow: false, until: '--:--', specials: [] });
   const [pif, setPif] = useState({ available: 0, contributed: 0 });
-  const [loyalty, setLoyalty] = useState({ current: 0, target: 8 });
-  const [freebiesLeft, setFreebiesLeft] = useState(0);
+  const [stats, setStats] = useState({ loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] });
   const [rumiQuote, setRumiQuote] = useState(null);
   const [igPost, setIgPost] = useState({ image: null, caption: '', url: null });
 
   useEffect(() => {
     getFundProgress().then(setFund).catch(() => setFund({ progress: 0, total_cents: 0, goal_cents: 0 }));
     getWeeklyHours().then(setWeekHours).catch(() => setWeekHours([]));
-    if (globalThis.freebiesLeft !== undefined) setFreebiesLeft(globalThis.freebiesLeft);
-    if (globalThis.loyaltyStamps !== undefined) setLoyalty({ current: globalThis.loyaltyStamps, target: 8 });
     let mounted = true;
     (async () => {
       try { const m = await getMembershipSummary(); if (mounted && m) setMember(prev => ({ ...prev, ...m })); } catch {}
@@ -59,15 +56,10 @@ export default function HomeScreen({ navigation }) {
       try { const t = await getToday(); if (mounted) setToday(t); } catch {}
       try { const s = await getPIFStats(); if (mounted) setPif(s); } catch {}
       try {
-        const { data: { session } } = await supabase.auth.getSession();
-        const stats = await getMyStats(session?.access_token);
+        const s = await getMyStats();
         if (mounted) {
-          const freebies = stats.freebiesLeft || 0;
-          const stamps = stats.loyaltyStamps || 0;
-          setFreebiesLeft(freebies);
-          setLoyalty({ current: stamps, target: 8 });
-          globalThis.freebiesLeft = freebies;
-          globalThis.loyaltyStamps = stamps;
+          setStats(s);
+          console.log('stats', s);
         }
       } catch {}
       try { const ig = await getLatestInstagramPost(); if (mounted) setIgPost(ig); } catch {}
@@ -141,13 +133,13 @@ export default function HomeScreen({ navigation }) {
                 </Animated.View>
               ) : null}
 
-              <View style={{ marginTop: 16 }}>
-                <LoyaltyStampTile count={loyalty.current} />
-              </View>
+            <View style={{ marginTop: 16 }}>
+              <LoyaltyStampTile count={stats.loyaltyStamps} />
+            </View>
 
-              {(member?.tier === 'paid' || freebiesLeft > 0) && (
+            {(member?.tier === 'paid' || stats.freebiesLeft > 0) && (
                 <View style={{ marginTop: 16 }}>
-                  <FreeDrinksCounter count={freebiesLeft} />
+                  <FreeDrinksCounter count={stats.freebiesLeft} />
                 </View>
               )}
             </View>

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -31,44 +31,34 @@ export default function MembershipScreen({ navigation }) {
   const insets = useSafeAreaInsets();
   const [summary, setSummary] = useState({ signedIn: false, tier: 'free', status: 'none', next_billing_at: null });
   const [pifSelfCents, setPifSelfCents] = useState(0);
-  const [stats, setStats] = useState({
-    loyaltyStamps: globalThis.loyaltyStamps ?? 0,
-    freebiesLeft: globalThis.freebiesLeft ?? 0,
-  });
-  const [vouchers, setVouchers] = useState([]);
+  const [stats, setStats] = useState({ loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] });
   const [page, setPage] = useState(0);
   const [user, setUser] = useState(null);
   const [session, setSession] = useState(null);
 
   const memberPayload = user ? `ruminate:${user.id}` : 'ruminate:member';
 
-  const totalPages = 1 + vouchers.length;
+  const totalPages = 1 + (stats.vouchers?.length || 0);
 
   const refresh = useCallback(async () => {
     try { const m = await getMembershipSummary(); if (m) setSummary(m); } catch {}
-    let token = '';
     if (supabase) {
       try {
         const { data: { session: sess } } = await supabase.auth.getSession();
         setSession(sess);
         setUser(sess?.user || null);
-        token = sess?.access_token || '';
       } catch {
         setSession(null);
         setUser(null);
       }
     }
     try {
-      const s = await getMyStats(token);
-
+      const s = await getMyStats();
       if (s.loyaltyStamps < 0 || s.loyaltyStamps > 7) {
         console.warn('[MEMBERSHIP] loyaltyStamps out of range', s.loyaltyStamps);
       }
-      setStats({ loyaltyStamps: s.loyaltyStamps, freebiesLeft: s.freebiesLeft });
-
-      setVouchers(Array.from(new Set((s.vouchers || []).filter(Boolean))));
-      globalThis.freebiesLeft = s.freebiesLeft;
-      globalThis.loyaltyStamps = s.loyaltyStamps;
+      setStats(s);
+      console.log('stats', s);
     } catch {}
   }, []);
 
@@ -79,20 +69,14 @@ export default function MembershipScreen({ navigation }) {
 
   useEffect(()=>{ 
     let m=true; 
-    const email=(typeof user!=='undefined'&&user&&user.email)
-      ? user.email
-      : (summary && summary.user && summary.user.email)
-      ? summary.user.email
-      : (globalThis && globalThis.auth && globalThis.auth.user && globalThis.auth.user.email)
-      ? globalThis.auth.user.email
-      : null; 
+    const email = user?.email || summary?.user?.email || null;
     if (!email) { setPifSelfCents(0); return; } 
     getPIFByEmail(email).then(r => { if (m) setPifSelfCents(Number(r.total_cents) || 0); }).catch(() => { if (m) setPifSelfCents(0); }); 
     return () => { m = false }; 
   }, [user, summary]);
 
   const [notice, setNotice] = useState('');
-  const prevFreebies = useRef(globalThis.lastFreebiesLeft ?? 0);
+  const prevFreebies = useRef(0);
 
   useEffect(() => {
     const prev = prevFreebies.current;
@@ -102,11 +86,9 @@ export default function MembershipScreen({ navigation }) {
       setNotice("You've earned a free drink!");
       const timeoutId = setTimeout(() => setNotice(''), 4000);
       prevFreebies.current = curr;
-      globalThis.lastFreebiesLeft = curr;
       return () => clearTimeout(timeoutId);
     }
     prevFreebies.current = curr;
-    globalThis.lastFreebiesLeft = curr;
     if (curr === 0) setNotice('');
   }, [stats?.freebiesLeft]);
 
@@ -135,7 +117,7 @@ export default function MembershipScreen({ navigation }) {
               <PagerView
                 style={{ height: 440, width: '100%' }}
                 initialPage={0}
-                key={`pv-${user?.id}-${vouchers.length}`}
+                key={`pv-${user?.id}-${stats.vouchers.length}`}
                 onPageSelected={e => setPage(e.nativeEvent.position)}
               >
                 <View key="member" style={[styles.card, styles.qrCard]}>
@@ -155,7 +137,7 @@ export default function MembershipScreen({ navigation }) {
                   </View>
                 </View>
 
-                {vouchers.map(code => (
+                {stats.vouchers.map(code => (
                   <View key={code} style={[styles.card, styles.qrCard, styles.voucherCard]}>
                     <Text style={[styles.cardTitle, styles.voucherTitle]}>Drink voucher</Text>
                     <View style={styles.qrWrap}>

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -1,16 +1,25 @@
-export async function getMyStats(token) {
-  const base = process.env.EXPO_PUBLIC_FUNCTIONS_URL || (process.env.EXPO_PUBLIC_SUPABASE_URL + '/functions/v1');
-  const r = await fetch(`${base}/me-stats`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token || ''}` },
-    body: JSON.stringify({}),
-  });
-  const json = await r.json().catch(() => ({}));
-  if (!r.ok) throw new Error(json?.error || `me-stats ${r.status}`);
-  const { loyaltyStamps, freebiesLeft, vouchers } = json;
-  if (![loyaltyStamps, freebiesLeft].every(n => Number.isFinite(n)) || !Array.isArray(vouchers)) {
-    throw new Error('Invalid me-stats payload');
-  }
-  return { loyaltyStamps, freebiesLeft, vouchers };
-}
+import { supabase } from '../lib/supabase';
 
+export async function getMyStats() {
+  try {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) return { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+
+    const base = process.env.EXPO_PUBLIC_FUNCTIONS_URL || process.env.FUNCTIONS_URL;
+    const res = await fetch(`${base}/me-stats`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    });
+    if (!res.ok) return { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+
+    const json = await res.json();
+    console.log('me-stats response', json);
+    return {
+      loyaltyStamps: Number(json?.loyaltyStamps ?? 0),
+      freebiesLeft: Number(json?.freebiesLeft ?? 0),
+      vouchers: Array.isArray(json?.vouchers) ? [...new Set(json.vouchers.filter(Boolean))] : [],
+    };
+  } catch {
+    return { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+  }
+}

--- a/supabase/functions/me-stats/index.ts
+++ b/supabase/functions/me-stats/index.ts
@@ -1,38 +1,46 @@
-import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { normalizeRewards } from "../_shared/rewards.ts";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+Deno.serve(async (req) => {
+  try {
+    const url = Deno.env.get("SUPABASE_URL")!;
+    const anon = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const service = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
-function cors() {
-  return {
-    "Access-Control-Allow-Origin": "*",
-    "Access-Control-Allow-Methods": "POST,OPTIONS",
-    "Access-Control-Allow-Headers": "authorization,content-type",
-  };
-}
+    const authHeader = req.headers.get("Authorization") || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : null;
+    if (!token) return new Response("Missing token", { status: 401 });
 
-serve(async (req: Request) => {
-  if (req.method === "OPTIONS") return new Response(null, { headers: cors() });
-  if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405, headers: cors() });
+    const supabaseAnon = createClient(url, anon);
+    const { data: auth, error: authErr } = await supabaseAnon.auth.getUser(token);
+    if (authErr || !auth?.user?.id) return new Response("Unauthorized", { status: 401 });
+    const userId = auth.user.id;
 
-  const authHeader = req.headers.get("Authorization") ?? "";
-  const auth = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, { global: { headers: { Authorization: authHeader } } });
-  const { data: { user } } = await auth.auth.getUser();
-  if (!user) return new Response("Unauthorized", { status: 401, headers: cors() });
+    const db = createClient(url, service, { auth: { persistSession: false } });
 
-  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
-  const stats = await normalizeRewards(admin, user.id);
-  console.log("[ME_STATS]", stats);
+    const { data: sumRow, error: sumErr } = await db
+      .from("loyalty_stamps")
+      .select("sum:stamps")
+      .eq("user_id", userId)
+      .single();
+    if (sumErr) throw sumErr;
+    const totalStamps = Number(sumRow?.sum ?? 0);
+    const remainder = totalStamps % 8;
 
-  return new Response(
-    JSON.stringify({
-      loyaltyStamps: stats.loyaltyStamps,
-      freebiesLeft: stats.freebiesLeft,
-      vouchers: stats.vouchers,
-    }),
-    { headers: { ...cors(), "content-type": "application/json" } }
-  );
+    const { data: voucherRows, error: vErr } = await db
+      .from("drink_vouchers")
+      .select("code")
+      .eq("user_id", userId)
+      .eq("redeemed", false)
+      .order("created_at", { ascending: true });
+    if (vErr) throw vErr;
+
+    const vouchers = (voucherRows || []).map((v) => v.code);
+    const res = { loyaltyStamps: remainder, freebiesLeft: vouchers.length, vouchers };
+
+    return new Response(JSON.stringify(res), {
+      headers: { "content-type": "application/json" },
+    });
+  } catch (e) {
+    return new Response(JSON.stringify({ error: String(e) }), { status: 500 });
+  }
 });


### PR DESCRIPTION
## Summary
- report loyalty and voucher counts from Edge function using service-role auth
- fetch user stats with Authorization header and show on Home and Membership screens
- simplify stamp and free drink components to render given counts

## Testing
- `npm test` *(fails: Missing script "test")*
- `node scripts/reset-rewards.js test@example.com` *(fails: Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY)*
- `node scripts/grant-rewards.js test@example.com 3 5` *(fails: Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68aabd865c1483229c2619f8558c4fa2