### PR TITLE
fix: show voucher pages in QR carousel

### DIFF
--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -39,7 +39,7 @@ export default function MembershipScreen({ navigation }) {
 
   const memberPayload = user ? `ruminate:${user.id}` : 'ruminate:member';
 
-  const totalPages = 1 + (stats?.freebiesLeft || 0);
+  const totalPages = 1 + vouchers.length;
 
   const refresh = useCallback(async () => {
     try { const m = await getMembershipSummary(); if (m) setSummary(m); } catch {}
@@ -68,7 +68,7 @@ export default function MembershipScreen({ navigation }) {
   useFocusEffect(useCallback(() => { let on = true; (async()=>{ if(on) await refresh(); })(); return () => { on = false; }; }, [refresh]));
 
   useEffect(() => {
-    setVouchers(Array.isArray(stats.vouchers) ? stats.vouchers : []);
+    setVouchers(Array.isArray(stats.vouchers) ? [...stats.vouchers] : []);
   }, [stats.vouchers]);
 
   useEffect(() => {
@@ -125,6 +125,7 @@ export default function MembershipScreen({ navigation }) {
 
             <View style={{ marginTop: 14 }}>
               <PagerView
+                key={vouchers.join(',')}
                 style={{ height: 440, width: '100%' }}
                 initialPage={0}
                 onPageSelected={e => setPage(e.nativeEvent.position)}
@@ -146,7 +147,7 @@ export default function MembershipScreen({ navigation }) {
                   </View>
                 </View>
 
-                {stats.vouchers.map(code => (
+                {vouchers.map(code => (
                   <View key={code} style={[styles.card, styles.qrCard, styles.voucherCard]}>
                     <Text style={[styles.cardTitle, styles.voucherTitle]}>Drink voucher</Text>
                     <View style={styles.qrWrap}>


### PR DESCRIPTION
## Summary
- compute QR carousel pages from server vouchers and re-render when vouchers change
- allow swiping to see each voucher, matching freebies count

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68aad12bd48c8322a7424c6ac91366f3