### PR TITLE
fix: sync vouchers for QR carousel

### DIFF
--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -11,6 +11,7 @@ import { palette } from '../design/theme';
 import { supabase } from '../lib/supabase';
 import { getMembershipSummary } from '../services/membership';
 import { getMyStats } from '../services/stats';
+import { syncVouchers } from '../services/vouchers';
 import GlowingGlassButton from '../components/GlowingGlassButton';
 import { getPIFByEmail } from '../services/pif';
 import { createReferral } from '../services/referral';
@@ -39,7 +40,7 @@ export default function MembershipScreen({ navigation }) {
 
   const memberPayload = user ? `ruminate:${user.id}` : 'ruminate:member';
 
-  const totalPages = 1 + (stats?.freebiesLeft || 0);
+  const totalPages = 1 + vouchers.length;
 
   const refresh = useCallback(async () => {
     try { const m = await getMembershipSummary(); if (m) setSummary(m); } catch {}
@@ -59,6 +60,12 @@ export default function MembershipScreen({ navigation }) {
         console.warn('[MEMBERSHIP] loyaltyStamps out of range', s.loyaltyStamps);
       }
       setStats(s);
+      if (s.freebiesLeft > 0) {
+        let codes = Array.isArray(s.vouchers) && s.vouchers.length === s.freebiesLeft ? s.vouchers : await syncVouchers();
+        setVouchers(Array.isArray(codes) ? codes.slice(0, s.freebiesLeft) : []);
+      } else {
+        setVouchers([]);
+      }
     } catch {}
   }, []);
 
@@ -66,10 +73,6 @@ export default function MembershipScreen({ navigation }) {
 
   useEffect(() => { refresh(); }, [refresh]);
   useFocusEffect(useCallback(() => { let on = true; (async()=>{ if(on) await refresh(); })(); return () => { on = false; }; }, [refresh]));
-
-  useEffect(() => {
-    setVouchers(Array.isArray(stats.vouchers) ? stats.vouchers : []);
-  }, [stats.vouchers]);
 
   useEffect(() => {
     if (page > totalPages - 1) {
@@ -125,6 +128,7 @@ export default function MembershipScreen({ navigation }) {
 
             <View style={{ marginTop: 14 }}>
               <PagerView
+                key={vouchers.join(',')}
                 style={{ height: 440, width: '100%' }}
                 initialPage={0}
                 onPageSelected={e => setPage(e.nativeEvent.position)}
@@ -146,7 +150,7 @@ export default function MembershipScreen({ navigation }) {
                   </View>
                 </View>
 
-                {stats.vouchers.map(code => (
+                {vouchers.map(code => (
                   <View key={code} style={[styles.card, styles.qrCard, styles.voucherCard]}>
                     <Text style={[styles.cardTitle, styles.voucherTitle]}>Drink voucher</Text>
                     <View style={styles.qrWrap}>


### PR DESCRIPTION
## Summary
- refresh vouchers from server so QR carousel matches freebies count
- render membership QR plus one page per voucher code

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68aad12bd48c8322a7424c6ac91366f3