### PR TITLE
feat(membership): sync voucher carousel with user rewards

### DIFF
--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -56,7 +56,9 @@ export default function MembershipScreen({ navigation }) {
     }
     try {
       let s = await getMyStats();
-      if (s.freebiesLeft > 0 && (!Array.isArray(s.vouchers) || s.vouchers.length !== s.freebiesLeft)) {
+      const mismatch = s.freebiesLeft !== (Array.isArray(s.vouchers) ? s.vouchers.length : 0);
+      const outOfRange = s.loyaltyStamps < 0 || s.loyaltyStamps > 7;
+      if (mismatch || outOfRange) {
         await syncVouchers();
         s = await getMyStats();
       }
@@ -64,6 +66,8 @@ export default function MembershipScreen({ navigation }) {
         console.warn('[MEMBERSHIP] loyaltyStamps out of range', s.loyaltyStamps);
       }
       setStats(s);
+      globalThis.freebiesLeft = s.freebiesLeft;
+      globalThis.loyaltyStamps = s.loyaltyStamps;
       setVouchers(Array.isArray(s.vouchers) ? s.vouchers.slice(0, s.freebiesLeft) : []);
 
     } catch {}

--- a/supabase/functions/_shared/rewards.ts
+++ b/supabase/functions/_shared/rewards.ts
@@ -21,12 +21,8 @@ export async function normalizeRewards(admin: SupabaseClient, userId: string) {
     .select("code")
     .eq("user_id", userId)
     .eq("redeemed", false)
-    .order("created_at", { ascending: true });
+    .order("created_at", { ascending: false });
   if (unredeemedErr) throw unredeemedErr;
-
-  const shouldExist = Math.floor(totalStamps / 8);
-  const toMint = Math.max(0, shouldExist - (totalVouchers ?? 0));
-
 
   const shouldExist = Math.floor((totalStamps ?? 0) / 8);
   const toMint = Math.max(0, shouldExist - (totalVouchers ?? 0));
@@ -44,7 +40,7 @@ export async function normalizeRewards(admin: SupabaseClient, userId: string) {
       .select("code")
       .eq("user_id", userId)
       .eq("redeemed", false)
-      .order("created_at", { ascending: true });
+      .order("created_at", { ascending: false });
     if (refreshErr) throw refreshErr;
     unredeemed = refreshed ?? [];
   }

--- a/supabase/functions/me-stats/index.ts
+++ b/supabase/functions/me-stats/index.ts
@@ -38,7 +38,7 @@ Deno.serve(async (req) => {
       .select('code')
       .eq('user_id', userId)
       .eq('redeemed', false)
-      .order('created_at', { ascending: true });
+      .order('created_at', { ascending: false });
     if (vErr) throw vErr;
     const vouchers = (voucherRows || []).map(v => v.code);
     const res = {


### PR DESCRIPTION
## Summary
- keep voucher list in sync by refreshing when stamp/voucher counts mismatch
- return newest vouchers first in stats and rewards sync
- store freebies and stamp counts globally for cross-screen consistency

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e1aab44832290cfdb873bd5e453