### PR TITLE
feat(membership): sync voucher carousel with user rewards

### DIFF
--- a/supabase/functions/_shared/rewards.ts
+++ b/supabase/functions/_shared/rewards.ts
@@ -21,12 +21,8 @@ export async function normalizeRewards(admin: SupabaseClient, userId: string) {
     .select("code")
     .eq("user_id", userId)
     .eq("redeemed", false)
-    .order("created_at", { ascending: true });
+    .order("created_at", { ascending: false });
   if (unredeemedErr) throw unredeemedErr;
-
-  const shouldExist = Math.floor(totalStamps / 8);
-  const toMint = Math.max(0, shouldExist - (totalVouchers ?? 0));
-
 
   const shouldExist = Math.floor((totalStamps ?? 0) / 8);
   const toMint = Math.max(0, shouldExist - (totalVouchers ?? 0));
@@ -44,7 +40,7 @@ export async function normalizeRewards(admin: SupabaseClient, userId: string) {
       .select("code")
       .eq("user_id", userId)
       .eq("redeemed", false)
-      .order("created_at", { ascending: true });
+      .order("created_at", { ascending: false });
     if (refreshErr) throw refreshErr;
     unredeemed = refreshed ?? [];
   }

--- a/supabase/functions/me-stats/index.ts
+++ b/supabase/functions/me-stats/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { normalizeRewards } from '../_shared/rewards.ts';
 
 Deno.serve(async (req) => {
   try {
@@ -7,7 +8,6 @@ Deno.serve(async (req) => {
     const service = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 
     const authHeader = req.headers.get('Authorization') || '';
-    console.log('Auth header', authHeader);
     const token = authHeader.startsWith('Bearer ')
       ? authHeader.slice(7)
       : null;
@@ -21,33 +21,11 @@ Deno.serve(async (req) => {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
     }
     const userId = auth.user.id;
-    console.log('Resolved userId', userId);
 
     const db = createClient(url, service, { auth: { persistSession: false } });
+    const stats = await normalizeRewards(db, userId);
 
-    const { data: sumRows, error: sumErr } = await db
-      .from('loyalty_stamps')
-      .select('sum(stamps)')
-      .eq('user_id', userId);
-    if (sumErr) throw sumErr;
-    const totalStamps = Number(sumRows?.[0]?.sum ?? 0);
-    const remainder = totalStamps % 8;
-
-    const { data: voucherRows, error: vErr } = await db
-      .from('drink_vouchers')
-      .select('code')
-      .eq('user_id', userId)
-      .eq('redeemed', false)
-      .order('created_at', { ascending: true });
-    if (vErr) throw vErr;
-    const vouchers = (voucherRows || []).map(v => v.code);
-    const res = {
-      loyaltyStamps: remainder,
-      freebiesLeft: vouchers.length,
-      vouchers,
-    };
-
-    return new Response(JSON.stringify(res), {
+    return new Response(JSON.stringify(stats), {
       headers: { 'content-type': 'application/json' },
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- keep voucher list in sync by refreshing when stamp/voucher counts mismatch
- return newest vouchers first in stats and rewards sync
- store freebies and stamp counts globally for cross-screen consistency
- normalize rewards during `me-stats` to mint missing vouchers and supply their codes
- load QR payload and voucher codes via `member-qrs` so carousel reflects available vouchers
- derive carousel vouchers from stats when member-qrs lacks codes
- drop sensitive logging from `me-stats`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e1aab44832290cfdb873bd5e453