### PR TITLE
fix(membership): bind voucher carousel to stats

### DIFF
--- a/supabase/functions/me-stats/index.ts
+++ b/supabase/functions/me-stats/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { normalizeRewards } from '../_shared/rewards.ts';
 
 Deno.serve(async (req) => {
   try {
@@ -7,7 +8,6 @@ Deno.serve(async (req) => {
     const service = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 
     const authHeader = req.headers.get('Authorization') || '';
-    console.log('Auth header', authHeader);
     const token = authHeader.startsWith('Bearer ')
       ? authHeader.slice(7)
       : null;
@@ -21,33 +21,11 @@ Deno.serve(async (req) => {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
     }
     const userId = auth.user.id;
-    console.log('Resolved userId', userId);
 
     const db = createClient(url, service, { auth: { persistSession: false } });
+    const stats = await normalizeRewards(db, userId);
 
-    const { data: sumRows, error: sumErr } = await db
-      .from('loyalty_stamps')
-      .select('sum(stamps)')
-      .eq('user_id', userId);
-    if (sumErr) throw sumErr;
-    const totalStamps = Number(sumRows?.[0]?.sum ?? 0);
-    const remainder = totalStamps % 8;
-
-    const { data: voucherRows, error: vErr } = await db
-      .from('drink_vouchers')
-      .select('code')
-      .eq('user_id', userId)
-      .eq('redeemed', false)
-      .order('created_at', { ascending: true });
-    if (vErr) throw vErr;
-    const vouchers = (voucherRows || []).map(v => v.code);
-    const res = {
-      loyaltyStamps: remainder,
-      freebiesLeft: vouchers.length,
-      vouchers,
-    };
-
-    return new Response(JSON.stringify(res), {
+    return new Response(JSON.stringify(stats), {
       headers: { 'content-type': 'application/json' },
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- derive visible vouchers from stats.vouchers or freebiesLeft
- reset pager when voucher count changes to keep pages in sync
- use stable keys so voucher pages render once per code
- roll over loyalty stamps on the server so 8 stamps mints 1 voucher and resets the remainder

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e1aab44832290cfdb873bd5e453