### PR TITLE
fix(membership): bind voucher carousel to stats

### DIFF
--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -12,6 +12,7 @@ import { supabase } from '../lib/supabase';
 import { getMembershipSummary } from '../services/membership';
 import { getMyStats } from '../services/stats';
 import { syncVouchers } from '../services/vouchers';
+import { getMemberQRCodes } from '../services/qr';
 import GlowingGlassButton from '../components/GlowingGlassButton';
 import { getPIFByEmail } from '../services/pif';
 import { createReferral } from '../services/referral';
@@ -33,30 +34,57 @@ export default function MembershipScreen({ navigation }) {
   const [summary, setSummary] = useState({ signedIn: false, tier: 'free', status: 'none', next_billing_at: null });
   const [pifSelfCents, setPifSelfCents] = useState(0);
   const [stats, setStats] = useState({ loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] });
-  const [vouchers, setVouchers] = useState([]);
+  const [memberPayload, setMemberPayload] = useState('ruminate:member');
   const [page, setPage] = useState(0);
   const [user, setUser] = useState(null);
   const [session, setSession] = useState(null);
+  const pagerRef = useRef(null);
 
-  const memberPayload = user ? `ruminate:${user.id}` : 'ruminate:member';
+  const vouchers = React.useMemo(() => {
+    if (Array.isArray(stats?.vouchers) && stats.vouchers.length) {
+      return stats.vouchers.map(code => ({ id: code, code, used: false, expiresAt: null }));
+    }
+    const n = Math.max(0, Number(stats?.freebiesLeft || 0));
+    return Array.from({ length: n }, (_, i) => ({
+      id: `local-${i}`,
+      code: `FREE-${i + 1}`,
+      used: false,
+      expiresAt: null,
+      isLocal: true,
+    }));
+  }, [stats?.vouchers, stats?.freebiesLeft]);
 
-  const totalPages = 1 + vouchers.length;
+  const isExpired = React.useCallback((iso) => {
+    if (!iso) return false;
+    return new Date(iso).getTime() < Date.now();
+  }, []);
+
+  const activeVouchers = React.useMemo(() =>
+    vouchers.filter(v => !v.used && !isExpired(v.expiresAt))
+  , [vouchers, isExpired]);
+
+  const totalPages = 1 + activeVouchers.length;
 
   const refresh = useCallback(async () => {
     try { const m = await getMembershipSummary(); if (m) setSummary(m); } catch {}
+    let uid = null;
     if (supabase) {
       try {
         const { data: { session: sess } } = await supabase.auth.getSession();
         setSession(sess);
         setUser(sess?.user || null);
+        uid = sess?.user?.id || null;
       } catch {
         setSession(null);
         setUser(null);
+        uid = null;
       }
     }
     try {
       let s = await getMyStats();
-      if (s.freebiesLeft > 0 && (!Array.isArray(s.vouchers) || s.vouchers.length !== s.freebiesLeft)) {
+      const mismatch = s.freebiesLeft !== (Array.isArray(s.vouchers) ? s.vouchers.length : 0);
+      const outOfRange = s.loyaltyStamps < 0 || s.loyaltyStamps > 7;
+      if (mismatch || outOfRange) {
         await syncVouchers();
         s = await getMyStats();
       }
@@ -64,7 +92,18 @@ export default function MembershipScreen({ navigation }) {
         console.warn('[MEMBERSHIP] loyaltyStamps out of range', s.loyaltyStamps);
       }
       setStats(s);
-      setVouchers(Array.isArray(s.vouchers) ? s.vouchers.slice(0, s.freebiesLeft) : []);
+      globalThis.freebiesLeft = s.freebiesLeft;
+      globalThis.loyaltyStamps = s.loyaltyStamps;
+
+      if (uid) {
+        setMemberPayload(`ruminate:member:${uid}`);
+        try {
+          const qrs = await getMemberQRCodes(uid);
+          if (qrs?.payload) setMemberPayload(qrs.payload);
+        } catch {}
+      } else {
+        setMemberPayload('ruminate:member');
+      }
 
     } catch {}
   }, []);
@@ -73,6 +112,13 @@ export default function MembershipScreen({ navigation }) {
 
   useEffect(() => { refresh(); }, [refresh]);
   useFocusEffect(useCallback(() => { let on = true; (async()=>{ if(on) await refresh(); })(); return () => { on = false; }; }, [refresh]));
+
+  useEffect(() => {
+    if (pagerRef.current && activeVouchers.length > 0) {
+      pagerRef.current.setPageWithoutAnimation(0);
+      setPage(0);
+    }
+  }, [activeVouchers.length]);
 
   useEffect(() => {
     if (page > totalPages - 1) {
@@ -128,7 +174,8 @@ export default function MembershipScreen({ navigation }) {
 
             <View style={{ marginTop: 14 }}>
               <PagerView
-                key={JSON.stringify(vouchers)}
+                ref={pagerRef}
+                key={`pv-${activeVouchers.length}`}
                 style={{ height: 440, width: '100%' }}
                 initialPage={0}
                 onPageSelected={e => setPage(e.nativeEvent.position)}
@@ -150,11 +197,11 @@ export default function MembershipScreen({ navigation }) {
                   </View>
                 </View>
 
-                {vouchers.map(code => (
-                  <View key={code} style={[styles.card, styles.qrCard, styles.voucherCard]}>
+                {activeVouchers.map(v => (
+                  <View key={v.id ?? v.code} style={[styles.card, styles.qrCard, styles.voucherCard]}>
                     <Text style={[styles.cardTitle, styles.voucherTitle]}>Drink voucher</Text>
                     <View style={styles.qrWrap}>
-                      <QRCode value={code} size={180} />
+                      <QRCode value={`ruminate:voucher:${v.code}`} size={180} />
                     </View>
                     <Text style={[styles.mutedSmall, styles.voucherText]}>
                       Show at the counter to redeem.

--- a/supabase/functions/me-stats/index.ts
+++ b/supabase/functions/me-stats/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { normalizeRewards } from '../_shared/rewards.ts';
 
 Deno.serve(async (req) => {
   try {
@@ -7,7 +8,6 @@ Deno.serve(async (req) => {
     const service = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 
     const authHeader = req.headers.get('Authorization') || '';
-    console.log('Auth header', authHeader);
     const token = authHeader.startsWith('Bearer ')
       ? authHeader.slice(7)
       : null;
@@ -21,33 +21,11 @@ Deno.serve(async (req) => {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
     }
     const userId = auth.user.id;
-    console.log('Resolved userId', userId);
 
     const db = createClient(url, service, { auth: { persistSession: false } });
+    const stats = await normalizeRewards(db, userId);
 
-    const { data: sumRows, error: sumErr } = await db
-      .from('loyalty_stamps')
-      .select('sum(stamps)')
-      .eq('user_id', userId);
-    if (sumErr) throw sumErr;
-    const totalStamps = Number(sumRows?.[0]?.sum ?? 0);
-    const remainder = totalStamps % 8;
-
-    const { data: voucherRows, error: vErr } = await db
-      .from('drink_vouchers')
-      .select('code')
-      .eq('user_id', userId)
-      .eq('redeemed', false)
-      .order('created_at', { ascending: true });
-    if (vErr) throw vErr;
-    const vouchers = (voucherRows || []).map(v => v.code);
-    const res = {
-      loyaltyStamps: remainder,
-      freebiesLeft: vouchers.length,
-      vouchers,
-    };
-
-    return new Response(JSON.stringify(res), {
+    return new Response(JSON.stringify(stats), {
       headers: { 'content-type': 'application/json' },
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- derive visible vouchers from stats.vouchers or freebiesLeft
- reset pager when voucher count changes to keep pages in sync
- use stable keys so voucher pages render once per code
- roll over loyalty stamps on the server so 8 stamps mints 1 voucher and resets the remainder
- deduplicate voucher filter variable to avoid compile-time collisions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e1aab44832290cfdb873bd5e453