### PR TITLE
fix voucher pages and add loyalty rollover

### DIFF
--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -59,17 +59,11 @@ export default function MembershipScreen({ navigation }) {
     return new Date(iso).getTime() < Date.now();
   }, []);
 
-  const activeVouchers = React.useMemo(() =>
-    vouchers.filter(v => !v.used && !isExpired(v.expiresAt))
-  , [vouchers, isExpired]);
-
-  const totalPages = 1 + activeVouchers.length;
-
   const visibleVouchers = React.useMemo(() =>
     vouchers.filter(v => !v.used && !isExpired(v.expiresAt))
   , [vouchers, isExpired]);
 
-  const totalPages = 1 + visibleVouchers.length;
+  const pageCount = 1 + visibleVouchers.length;
   const refresh = useCallback(async () => {
     try { const m = await getMembershipSummary(); if (m) setSummary(m); } catch {}
     let uid = null;
@@ -120,17 +114,17 @@ export default function MembershipScreen({ navigation }) {
 
   useEffect(() => {
 
-    if (pagerRef.current && activeVouchers.length > 0) {
+    if (pagerRef.current && visibleVouchers.length > 0) {
       pagerRef.current.setPageWithoutAnimation(0);
       setPage(0);
     }
-  }, [activeVouchers.length]);
+  }, [visibleVouchers.length]);
 
   useEffect(() => {
-    if (page > totalPages - 1) {
-      setPage(Math.max(0, totalPages - 1));
+    if (page > pageCount - 1) {
+      setPage(Math.max(0, pageCount - 1));
     }
-  }, [totalPages, page]);
+  }, [pageCount, page]);
 
   useEffect(()=>{
     let m=true; 
@@ -182,7 +176,7 @@ export default function MembershipScreen({ navigation }) {
               <PagerView
                 ref={pagerRef}
 
-                key={`pv-${activeVouchers.length}`}
+                key={`pv-${visibleVouchers.length}`}
 
                 style={{ height: 440, width: '100%' }}
                 initialPage={0}
@@ -204,7 +198,7 @@ export default function MembershipScreen({ navigation }) {
                     />
                   </View>
                 </View>
-          {activeVouchers.map(v => (
+          {visibleVouchers.map(v => (
 
                   <View key={v.id ?? v.code} style={[styles.card, styles.qrCard, styles.voucherCard]}>
                     <Text style={[styles.cardTitle, styles.voucherTitle]}>Drink voucher</Text>
@@ -217,11 +211,11 @@ export default function MembershipScreen({ navigation }) {
                   </View>
                 ))}
               </PagerView>
-              {totalPages > 1 && (
+              {pageCount > 1 && (
                 <>
                   <Text style={styles.swipePrompt}>Swipe to see your drink vouchers</Text>
                   <View style={styles.dots}>
-                    {Array.from({ length: totalPages }).map((_, i) => (
+                    {Array.from({ length: pageCount }).map((_, i) => (
                       <View
                         key={i}
                         style={[styles.dot, i === page && styles.dotActive]}

--- a/supabase/functions/_shared/rewards.ts
+++ b/supabase/functions/_shared/rewards.ts
@@ -1,6 +1,6 @@
 import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-function applyStampAccrual(prevStamps: number, delta: number) {
+export function applyStampAccrual(prevStamps: number, delta: number) {
   const start = Math.max(0, Number(prevStamps || 0));
   const inc = Math.max(0, Number(delta || 0));
   const total = start + inc;

--- a/supabase/functions/loyalty-redeem/index.ts
+++ b/supabase/functions/loyalty-redeem/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { applyStampAccrual } from "../_shared/rewards.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
@@ -10,16 +11,6 @@ function cors() {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "POST,OPTIONS",
     "Access-Control-Allow-Headers": "authorization,content-type",
-  };
-}
-
-function applyStampAccrual(prevStamps: number, delta: number) {
-  const start = Math.max(0, Number(prevStamps || 0));
-  const inc = Math.max(0, Number(delta || 0));
-  const total = start + inc;
-  return {
-    vouchersEarned: Math.floor(total / 8),
-    stampsRemainder: total % 8,
   };
 }
 


### PR DESCRIPTION
## Summary
- fix duplicate voucher/page variables on Membership screen
- export loyalty stamp accrual helper and reuse in loyalty-redeem function

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adb2d632d48322a55663030c42440e