### PR TITLE
feat(menu): fetch items from Supabase and add cart context

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { StatusBar, ImageBackground } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Router from './src/navigation/Router';
+import { CartProvider } from './src/contexts/CartContext';
 import { useFonts, Fraunces_600SemiBold, Fraunces_700Bold } from '@expo-google-fonts/fraunces';
 import appBgBase64 from './assets/appBgBase64';
 
@@ -21,7 +22,9 @@ export default function App() {
     >
       <SafeAreaProvider>
         <StatusBar barStyle="dark-content" />
-        <Router />
+        <CartProvider>
+          <Router />
+        </CartProvider>
       </SafeAreaProvider>
     </ImageBackground>
   );

--- a/src/contexts/CartContext.js
+++ b/src/contexts/CartContext.js
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const CartContext = createContext({ items: [], addItem: () => {} });
+
+export function CartProvider({ children }) {
+  const [items, setItems] = useState([]);
+  const addItem = (item) => {
+    setItems((prev) => [...prev, item]);
+  };
+  return (
+    <CartContext.Provider value={{ items, addItem }}>
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  return useContext(CartContext);
+}
+

--- a/src/screens/MenuScreen.js
+++ b/src/screens/MenuScreen.js
@@ -1,18 +1,81 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+  Modal,
+} from 'react-native';
 import { palette } from '../design/theme';
+import { getMenuItems } from '../services/menu';
+import { useCart } from '../contexts/CartContext';
 
 export default function MenuScreen() {
   const insets = useSafeAreaInsets();
+  const { addItem } = useCart();
+  const [items, setItems] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [shots, setShots] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      const data = await getMenuItems();
+      if (active) setItems(data);
+    })();
+    return () => { active = false; };
+  }, []);
+
+  const priceWithShots = () => {
+    if (!selected) return 0;
+    const shotPrice = selected?.options?.syrupShotPrice || selected?.options?.syrup_shot_price || 0;
+    return selected.base_price + shots * shotPrice;
+  };
+
+  const addToCart = () => {
+    addItem({ ...selected, shots, price: priceWithShots() });
+    setSelected(null);
+  };
+
+  const renderItem = ({ item }) => (
+    <Pressable style={styles.itemCard} onPress={() => { setSelected(item); setShots(0); }}>
+      <Text style={styles.itemName}>{item.name}</Text>
+      <Text style={styles.itemPrice}>${item.base_price?.toFixed(2)}</Text>
+    </Pressable>
+  );
+
   return (
     <SafeAreaView style={styles.container} edges={['left','right']}>
-      <View style={[styles.header, { paddingTop: insets.top }] }><Text style={styles.headerTitle}>Menu</Text></View>
-      <ScrollView contentContainerStyle={styles.content}>
-        <View style={styles.card}>
-          <Text style={styles.body}>Menu coming soon.</Text>
+      <View style={[styles.header, { paddingTop: insets.top }]}><Text style={styles.headerTitle}>Menu</Text></View>
+      <FlatList
+        data={items}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={renderItem}
+        numColumns={2}
+        contentContainerStyle={styles.list}
+      />
+      <Modal visible={!!selected} transparent animationType="slide" onRequestClose={() => setSelected(null)}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>{selected?.name}</Text>
+            {['coffee', 'matcha'].includes(selected?.type) && (
+              <View style={styles.shotRow}>
+                <Text style={styles.shotLabel}>Syrup shots:</Text>
+                <View style={styles.shotCtrls}>
+                  <Pressable onPress={() => setShots(Math.max(0, shots - 1))} style={styles.ctrlBtn}><Text style={styles.ctrlTxt}>-</Text></Pressable>
+                  <Text style={styles.shotCount}>{shots}</Text>
+                  <Pressable onPress={() => setShots(shots + 1)} style={styles.ctrlBtn}><Text style={styles.ctrlTxt}>+</Text></Pressable>
+                </View>
+              </View>
+            )}
+            <Text style={styles.modalPrice}>${priceWithShots().toFixed(2)}</Text>
+            <Pressable style={styles.addBtn} onPress={addToCart}><Text style={styles.addTxt}>Add to cart</Text></Pressable>
+            <Pressable style={styles.closeBtn} onPress={() => setSelected(null)}><Text style={styles.closeTxt}>Close</Text></Pressable>
+          </View>
         </View>
-      </ScrollView>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -32,15 +95,31 @@ const styles = StyleSheet.create({
     zIndex: 10,
   },
   headerTitle: { fontSize: 20, color: '#3E2723', fontFamily: 'Fraunces_700Bold' },
-  content: { padding: 16, paddingBottom: 120 },
-  title: { fontSize: 24, color: palette.coffee, fontFamily: 'Fraunces_700Bold' },
-  card: {
-    marginTop: 16,
+  list: { padding: 16, paddingBottom: 120 },
+  itemCard: {
+    flex: 1,
     backgroundColor: palette.paper,
     borderColor: palette.border,
     borderWidth: 1,
     borderRadius: 14,
     padding: 16,
+    margin: 8,
   },
-  body: { color: palette.coffee, fontFamily: 'Fraunces_600SemiBold' },
+  itemName: { color: palette.coffee, fontFamily: 'Fraunces_700Bold', marginBottom: 4 },
+  itemPrice: { color: palette.coffee, fontFamily: 'Fraunces_600SemiBold' },
+  modalOverlay: { flex:1, backgroundColor:'rgba(0,0,0,0.5)', justifyContent:'center', alignItems:'center' },
+  modalContent: { backgroundColor: palette.paper, borderRadius: 14, padding:20, width:'80%' },
+  modalTitle: { fontSize:20, color: palette.coffee, fontFamily:'Fraunces_700Bold', marginBottom:12 },
+  shotRow: { flexDirection:'row', alignItems:'center', marginBottom:12, justifyContent:'space-between' },
+  shotLabel: { color: palette.coffee, fontFamily:'Fraunces_600SemiBold' },
+  shotCtrls: { flexDirection:'row', alignItems:'center', gap:12 },
+  ctrlBtn: { paddingHorizontal:12, paddingVertical:6, backgroundColor: palette.cream, borderRadius:8 },
+  ctrlTxt: { fontSize:18, color: palette.coffee },
+  shotCount: { fontSize:16, color: palette.coffee },
+  modalPrice: { fontSize:18, color: palette.coffee, fontFamily:'Fraunces_700Bold', marginBottom:12 },
+  addBtn: { backgroundColor: palette.coffee, padding:12, borderRadius:8, alignItems:'center', marginBottom:8 },
+  addTxt: { color:'#fff', fontFamily:'Fraunces_700Bold' },
+  closeBtn: { alignItems:'center', padding:8 },
+  closeTxt: { color: palette.coffee, fontFamily:'Fraunces_600SemiBold' },
 });
+

--- a/src/services/menu.js
+++ b/src/services/menu.js
@@ -1,0 +1,26 @@
+import { supabase, hasSupabase } from '../lib/supabase';
+import { getCMS } from './cms';
+
+export async function getMenuItems() {
+  if (!hasSupabase || !supabase) return [];
+  try {
+    const { data, error } = await supabase
+      .from('menu_items')
+      .select('id,name,type,base_price,options,cms_key');
+    if (error) return [];
+    const cms = await getCMS();
+    return (data || [])
+      .filter(item => {
+        if (!item.cms_key) return true;
+        const val = cms[item.cms_key];
+        return typeof val !== 'undefined' && val !== null && val !== '';
+      })
+      .map(item => ({
+        ...item,
+        name: cms[item.cms_key] || item.name,
+      }));
+  } catch {
+    return [];
+  }
+}
+


### PR DESCRIPTION
## Summary
- add menu service fetching Supabase `menu_items` and filtering via CMS keys
- display Supabase items in Menu screen with syrup shots and cart integration
- introduce simple Cart context and wrap app with provider

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68adbfa2bb6483228c5a83993f62d5a4