### PR TITLE
feat: add cart context and tab badge

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,6 +2,7 @@ import 'react-native-gesture-handler';
 import React from 'react';
 import { StatusBar, ImageBackground } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { CartProvider } from './src/context/CartContext';
 import Router from './src/navigation/Router';
 import { useFonts, Fraunces_600SemiBold, Fraunces_700Bold } from '@expo-google-fonts/fraunces';
 import appBgBase64 from './assets/appBgBase64';
@@ -19,10 +20,12 @@ export default function App() {
       source={{ uri: `data:image/png;base64,${appBgBase64}` }}
       style={{ flex: 1 }}
     >
-      <SafeAreaProvider>
-        <StatusBar barStyle="dark-content" />
-        <Router />
-      </SafeAreaProvider>
+      <CartProvider>
+        <SafeAreaProvider>
+          <StatusBar barStyle="dark-content" />
+          <Router />
+        </SafeAreaProvider>
+      </CartProvider>
     </ImageBackground>
   );
 }

--- a/src/context/CartContext.js
+++ b/src/context/CartContext.js
@@ -1,0 +1,42 @@
+import React, { createContext, useState, useMemo } from 'react';
+
+export const CartContext = createContext({
+  items: [],
+  addItem: () => {},
+  removeItem: () => {},
+  clear: () => {},
+  itemCount: 0,
+  subtotal: 0,
+});
+
+export function CartProvider({ children }) {
+  const [items, setItems] = useState([]);
+
+  const addItem = (item) => {
+    setItems((prev) => {
+      const existing = prev.find((i) => i.id === item.id);
+      if (existing) {
+        return prev.map((i) =>
+          i.id === item.id ? { ...i, quantity: i.quantity + (item.quantity || 1) } : i
+        );
+      }
+      return [...prev, { ...item, quantity: item.quantity || 1 }];
+    });
+  };
+
+  const removeItem = (id) => {
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  };
+
+  const clear = () => setItems([]);
+
+  const itemCount = items.reduce((sum, i) => sum + i.quantity, 0);
+  const subtotal = items.reduce((sum, i) => sum + (i.price || 0) * i.quantity, 0);
+
+  const value = useMemo(
+    () => ({ items, addItem, removeItem, clear, itemCount, subtotal }),
+    [items, itemCount, subtotal]
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}

--- a/src/navigation/SwipeTabs.js
+++ b/src/navigation/SwipeTabs.js
@@ -1,6 +1,6 @@
 
-import React, { useState, useEffect } from 'react';
-import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
+import React, { useState, useEffect, useContext } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import { BlurView } from 'expo-blur';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -13,11 +13,14 @@ import MembershipScreen from '../screens/MembershipScreen';
 import CommunityScreen from '../screens/CommunityScreen';
 import AdminScreen from '../screens/AdminScreen';
 import { supabase } from '../lib/supabase';
+import CartScreen from '../screens/CartScreen';
+import { CartContext } from '../context/CartContext';
 
 const Tab = createMaterialTopTabNavigator();
 
 function GlassTabBar({ state, descriptors, navigation }) {
   const insets = useSafeAreaInsets();
+  const { itemCount } = useContext(CartContext);
   return (
     <View pointerEvents="box-none" style={[styles.tabWrap, { paddingBottom: (insets.bottom || 8) + 4 }]}>
       <BlurView intensity={90} tint="dark" style={styles.glass}>
@@ -38,7 +41,14 @@ function GlassTabBar({ state, descriptors, navigation }) {
           const Icon = options.tabBarIcon;
           return (
             <Pressable key={route.key} onPress={onPress} style={[styles.tabBtn, isFocused && styles.tabBtnActive]}>
-              {Icon ? Icon({ focused: isFocused, color: isFocused ? '#FFF7E6' : 'rgba(255,247,230,0.7)' }) : null}
+              <View style={{ position: 'relative' }}>
+                {Icon ? Icon({ focused: isFocused, color: isFocused ? '#FFF7E6' : 'rgba(255,247,230,0.7)' }) : null}
+                {route.name === 'Cart' && itemCount > 0 && (
+                  <View style={styles.badge}>
+                    <Text style={styles.badgeText}>{itemCount}</Text>
+                  </View>
+                )}
+              </View>
               <Text style={[styles.tabLabel, isFocused && styles.tabLabelActive]} numberOfLines={1}>{label}</Text>
             </Pressable>
           );
@@ -50,6 +60,7 @@ function GlassTabBar({ state, descriptors, navigation }) {
 
 export default function SwipeTabs() {
   const [signedIn, setSignedIn] = useState(false);
+  const { items } = useContext(CartContext);
 
   useEffect(() => {
     let active = true;
@@ -100,6 +111,13 @@ export default function SwipeTabs() {
         component={CommunityScreen}
         options={{ title: 'Community', tabBarIcon: ({ color }) => <Ionicons name="people-outline" size={22} color={color} /> }}
       />
+      {items.length > 0 && (
+        <Tab.Screen
+          name="Cart"
+          component={CartScreen}
+          options={{ title: 'Cart', tabBarIcon: ({ color }) => <Ionicons name="cart-outline" size={22} color={color} /> }}
+        />
+      )}
       {signedIn && (
         <Tab.Screen
           name="Admin"
@@ -134,4 +152,17 @@ const styles = StyleSheet.create({
   tabBtnActive: { backgroundColor: 'rgba(255,247,230,0.2)' },
   tabLabel: { fontSize: 11, color: 'rgba(255,247,230,0.7)', fontWeight: '600' },
   tabLabelActive: { color: '#FFF7E6' },
+  badge: {
+    position: 'absolute',
+    top: -4,
+    right: -10,
+    backgroundColor: '#FF6B00',
+    borderRadius: 8,
+    minWidth: 16,
+    height: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 2,
+  },
+  badgeText: { color: '#FFF', fontSize: 10, fontWeight: '700' },
 });

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -1,0 +1,51 @@
+import React, { useContext } from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { CartContext } from '../context/CartContext';
+
+export default function CartScreen() {
+  const { items, subtotal } = useContext(CartContext);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <FlatList
+        data={items}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <Text style={styles.name}>{item.name}</Text>
+            <Text style={styles.qty}>x{item.quantity}</Text>
+            <Text style={styles.price}>${(item.price * item.quantity).toFixed(2)}</Text>
+          </View>
+        )}
+        ListEmptyComponent={<Text style={styles.empty}>Your cart is empty.</Text>}
+      />
+      <View style={styles.footer}>
+        <Text style={styles.subtotalLabel}>Subtotal</Text>
+        <Text style={styles.subtotalValue}>${subtotal.toFixed(2)}</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  name: { fontSize: 16 },
+  qty: { fontSize: 16 },
+  price: { fontSize: 16 },
+  empty: { textAlign: 'center', marginTop: 20 },
+  footer: {
+    borderTopWidth: 1,
+    borderColor: '#ccc',
+    paddingTop: 10,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  subtotalLabel: { fontWeight: 'bold' },
+  subtotalValue: { fontWeight: 'bold' },
+});

--- a/src/screens/MenuScreen.js
+++ b/src/screens/MenuScreen.js
@@ -1,18 +1,40 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, FlatList, Pressable } from 'react-native';
 import { palette } from '../design/theme';
+import { CartContext } from '../context/CartContext';
+
+const MENU_ITEMS = [
+  { id: 'latte', name: 'Latte', price: 4.5 },
+  { id: 'espresso', name: 'Espresso', price: 3 },
+  { id: 'tea', name: 'Tea', price: 3.25 },
+];
 
 export default function MenuScreen() {
   const insets = useSafeAreaInsets();
+  const { addItem } = useContext(CartContext);
+
+  const renderItem = ({ item }) => (
+    <View style={styles.card}>
+      <View>
+        <Text style={styles.itemName}>{item.name}</Text>
+        <Text style={styles.itemPrice}>${item.price.toFixed(2)}</Text>
+      </View>
+      <Pressable style={styles.addBtn} onPress={() => addItem(item)}>
+        <Text style={styles.addBtnText}>Add to cart</Text>
+      </Pressable>
+    </View>
+  );
+
   return (
     <SafeAreaView style={styles.container} edges={['left','right']}>
       <View style={[styles.header, { paddingTop: insets.top }] }><Text style={styles.headerTitle}>Menu</Text></View>
-      <ScrollView contentContainerStyle={styles.content}>
-        <View style={styles.card}>
-          <Text style={styles.body}>Menu coming soon.</Text>
-        </View>
-      </ScrollView>
+      <FlatList
+        contentContainerStyle={styles.content}
+        data={MENU_ITEMS}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+      />
     </SafeAreaView>
   );
 }
@@ -32,15 +54,25 @@ const styles = StyleSheet.create({
     zIndex: 10,
   },
   headerTitle: { fontSize: 20, color: '#3E2723', fontFamily: 'Fraunces_700Bold' },
-  content: { padding: 16, paddingBottom: 120 },
+  content: { padding: 16, paddingBottom: 120, gap: 16 },
   title: { fontSize: 24, color: palette.coffee, fontFamily: 'Fraunces_700Bold' },
   card: {
-    marginTop: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     backgroundColor: palette.paper,
     borderColor: palette.border,
     borderWidth: 1,
     borderRadius: 14,
     padding: 16,
   },
-  body: { color: palette.coffee, fontFamily: 'Fraunces_600SemiBold' },
+  itemName: { fontSize: 18, color: palette.coffee, fontFamily: 'Fraunces_700Bold' },
+  itemPrice: { color: palette.coffee, fontFamily: 'Fraunces_600SemiBold' },
+  addBtn: {
+    backgroundColor: palette.clay,
+    borderRadius: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+  },
+  addBtnText: { color: '#fff', fontFamily: 'Fraunces_700Bold', fontSize: 14 },
 });


### PR DESCRIPTION
## Summary
- add cart context with items and subtotal
- wrap app in CartProvider
- show cart tab with badge when items exist
- allow adding menu items to cart from menu screen

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adbfadb6908322aa2477243ac6b581