### PR TITLE
feat: add splash gate overlay for loading signals

### DIFF
--- a/App.js
+++ b/App.js
@@ -6,6 +6,7 @@ import { CartProvider } from './src/context/CartContext';
 import Router from './src/navigation/Router';
 import { useFonts, Fraunces_600SemiBold, Fraunces_700Bold } from '@expo-google-fonts/fraunces';
 import appBgBase64 from './assets/appBgBase64';
+import SplashGate from './src/components/SplashGate';
 
 export default function App() {
   const [loaded] = useFonts({ Fraunces_600SemiBold, Fraunces_700Bold });
@@ -26,6 +27,7 @@ export default function App() {
         <CartProvider>
           <Router />
         </CartProvider>
+        <SplashGate />
       </SafeAreaProvider>
     </ImageBackground>
   );

--- a/src/boot/loadingSignals.ts
+++ b/src/boot/loadingSignals.ts
@@ -1,0 +1,53 @@
+type Keys = 'auth' | 'stamps' | 'cms';
+type Listener = (state: Record<Keys, boolean>) => void;
+
+const state: Record<Keys, boolean> = { auth: false, stamps: false, cms: false };
+const listeners = new Set<Listener>();
+
+// Keep original console.log
+const originalLog = console.log;
+
+// Wrap console.log once; detect exact phrases (case-insensitive contains)
+let patched = false;
+export function patchConsoleForLoadingSignals() {
+  if (patched) return;
+  patched = true;
+  console.log = (...args: any[]) => {
+    try {
+      const msg = args.map(String).join(' ');
+      const lower = msg.toLowerCase();
+
+      if (lower.includes('user is signed in')) {
+        state.auth = true; notify();
+      }
+      if (lower.includes('loyalty stamps and free drinks have been received')) {
+        state.stamps = true; notify();
+      }
+      if (lower.includes('cms info has all been received')) {
+        state.cms = true; notify();
+      }
+    } catch {}
+    // always forward to original log
+    originalLog(...args);
+  };
+}
+
+export function subscribe(fn: Listener) {
+  listeners.add(fn);
+  // immediate push
+  fn({ ...state });
+  return () => listeners.delete(fn);
+}
+
+function notify() {
+  const snapshot = { ...state };
+  listeners.forEach(fn => { try { fn(snapshot); } catch {} });
+}
+
+// Optional: for manual marking from code instead of console text
+export function markLoaded(key: Keys) {
+  if (!state[key]) { state[key] = true; notify(); }
+}
+
+// Expose read-only
+export function getLoadingState() { return { ...state }; }

--- a/src/components/SplashGate.tsx
+++ b/src/components/SplashGate.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { palette } from '../design/theme';
+import logo from '../../assets/logo.png';
+import {
+  patchConsoleForLoadingSignals,
+  subscribe,
+  getLoadingState,
+} from '../boot/loadingSignals';
+
+const LINES = [
+  'collecting beans…',
+  'fresh roasting…',
+  'grinding coffee…',
+  'brewing espresso…',
+  'steaming milk…',
+  'tamping the puck…',
+  'dialling in…',
+];
+
+const HARD_TIMEOUT_MS = 30000; // 30s
+const ROTATE_MS = 1500;
+
+export default function SplashGate() {
+  const insets = useSafeAreaInsets();
+  const [visible, setVisible] = useState(true);
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    patchConsoleForLoadingSignals();
+
+    const unsub = subscribe((st) => {
+      if (st.auth && st.stamps && st.cms) setVisible(false);
+    });
+
+    const tmr = setTimeout(() => setVisible(false), HARD_TIMEOUT_MS);
+    const rot = setInterval(() => setIdx(i => (i + 1) % LINES.length), ROTATE_MS);
+
+    // If all are already ready (e.g. dev reload), hide immediately
+    const s = getLoadingState();
+    if (s.auth && s.stamps && s.cms) setVisible(false);
+
+    return () => {
+      unsub?.();
+      clearTimeout(tmr);
+      clearInterval(rot);
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <View style={[styles.wrap, { paddingTop: insets.top, paddingBottom: insets.bottom }]}> 
+      <Image source={logo} style={styles.logo} />
+      <Text style={styles.line}>{LINES[idx]}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    position: 'absolute',
+    zIndex: 9999,
+    left: 0, right: 0, top: 0, bottom: 0,
+    backgroundColor: palette.coffee,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  logo: { width: 120, height: 120, resizeMode: 'contain', marginBottom: 16 },
+  line: {
+    color: '#F8EBDD',
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add loadingSignals singleton to watch console logs and track auth, stamp, and CMS readiness
- display SplashGate overlay with rotating coffee messages and 30s timeout
- mount SplashGate at root so UI waits for signals before showing content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: scripts/repair-home.js(10,133): error TS1127: Invalid character.)*


------
https://chatgpt.com/codex/tasks/task_e_68aed44d6d0c83228b502cd5deeb7eed