### PR TITLE
Trigger startup loading signals in SplashGate

### DIFF
--- a/src/components/SplashGate.tsx
+++ b/src/components/SplashGate.tsx
@@ -9,7 +9,11 @@ import {
   patchConsoleForLoadingSignals,
   subscribe,
   getLoadingState,
+  markLoaded,
 } from '../boot/loadingSignals';
+import { supabase } from '../lib/supabase';
+import { getMyStats } from '../services/stats';
+import { getCMS } from '../services/cms';
 
 const LINES = [
   'collecting beans…',
@@ -34,6 +38,15 @@ export default function SplashGate() {
 
   useEffect(() => {
     patchConsoleForLoadingSignals();
+
+    if (supabase?.auth) {
+      supabase.auth.getSession().catch(() => {}).finally(() => markLoaded('auth'));
+    } else {
+      markLoaded('auth');
+    }
+
+    getMyStats().catch(() => {}).finally(() => markLoaded('stamps'));
+    getCMS().catch(() => {}).finally(() => markLoaded('cms'));
 
     const unsub = subscribe((st) => {
       if (st.auth && st.stamps && st.cms) setVisible(false);


### PR DESCRIPTION
## Summary
- Launch auth, stats, and CMS tasks on mount
- Mark loading signals for each data source when resolved
- Keep console patching as a fallback for loading signals

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aedea9d9408322a738dff5bf323205