### PR TITLE
fix: wire auth splash signal and shorten timeout

### DIFF
--- a/src/components/SplashGate.tsx
+++ b/src/components/SplashGate.tsx
@@ -25,7 +25,7 @@ const LINES = [
   'dialling in…',
 ];
 
-const HARD_TIMEOUT_MS = 30000; // 30s
+const HARD_TIMEOUT_MS = 12000; // 12s
 const ROTATE_MS = 3000;
 const FADE_MS = 300;
 

--- a/src/services/membership.js
+++ b/src/services/membership.js
@@ -11,6 +11,8 @@ export async function getMembershipSummary() {
       return { signedIn: false, tier: 'free', status: 'none', next_billing_at: null };
     }
 
+    console.log('user is signed in');
+
     const meta = session.user.user_metadata || {};
     // For testing, force specific user email to be treated as paid tier
     // regardless of metadata.


### PR DESCRIPTION
## Summary
- log when auth session exists so splash gate receives 'user is signed in'
- reduce splash screen timeout from 30s to 12s

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aee7414d9083228b4c41f262afd707