### PR TITLE
feat(menu): fade item detail modal

### DIFF
--- a/src/boot/loadingSignals.ts
+++ b/src/boot/loadingSignals.ts
@@ -52,7 +52,12 @@ function notify() {
 }
 
 function scheduleNotify() {
-  setTimeout(notify, 0);
+  if (typeof requestAnimationFrame === 'function') {
+    // Delay until next frame so React isn't mid-insertion effect when listeners update state
+    requestAnimationFrame(() => notify());
+  } else {
+    setTimeout(notify, 0);
+  }
 
 }
 

--- a/src/screens/MenuScreen.js
+++ b/src/screens/MenuScreen.js
@@ -159,7 +159,7 @@ export default function MenuScreen() {
           </View>
         )}
       </ScrollView>
-      <Modal visible={!!selected} transparent animationType="slide" onRequestClose={() => setSelected(null)}>
+      <Modal visible={!!selected} transparent animationType="fade" onRequestClose={() => setSelected(null)}>
         <View style={styles.modalOverlay}>
           <View style={styles.modalContent}>
             {selected?.image && <Image source={{ uri: selected.image }} style={styles.modalImage} />}


### PR DESCRIPTION
## Summary
- switch menu item detail modal to fade in
- defer loading notifications to avoid useInsertionEffect warning

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af27e0f0e88322bf77600395a9dbc5