### PR TITLE
feat(menu): parse CMS menu and add configurable item modifiers

### DIFF
--- a/src/components/MenuItemDetail.js
+++ b/src/components/MenuItemDetail.js
@@ -1,0 +1,139 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, View, Text, ScrollView, Pressable, StyleSheet } from 'react-native';
+import { palette } from '../design/theme';
+import { computeItemTotal } from '../services/menuData.js';
+
+export default function MenuItemDetail({ item, options, visible, onClose, onAdd }) {
+  const [altMilk, setAltMilk] = useState(null);
+  const [coffeeBlend, setCoffeeBlend] = useState('house');
+  const [extraShots, setExtraShots] = useState(0);
+  const [syrups, setSyrups] = useState({}); // key -> count
+
+  useEffect(() => {
+    setAltMilk(null);
+    setCoffeeBlend('house');
+    setExtraShots(0);
+    setSyrups({});
+  }, [item]);
+
+  const syrupCount = useMemo(() => Object.values(syrups).reduce((a,b)=>a+b,0), [syrups]);
+  const total = useMemo(() => computeItemTotal(item?.price || 0, { syrupCount, extraShots }), [item, syrupCount, extraShots]);
+
+  const add = () => {
+    const modifiers = {};
+    if (item.flags.alt && altMilk) modifiers.altMilk = altMilk;
+    if (item.flags.coffee) {
+      const blendLabel = options.coffeeBlends.find(b=>b.key===coffeeBlend)?.label || 'House blend';
+      modifiers.coffeeBlend = blendLabel;
+    }
+    if (item.flags.syrups) {
+      const chosen = [];
+      for (const [key,count] of Object.entries(syrups)) {
+        const label = options.syrups.find(s=>s.key===key)?.label;
+        for (let i=0;i<count;i++) chosen.push(label);
+      }
+      if (chosen.length) modifiers.syrups = chosen;
+    }
+    if (item.flags.extra && extraShots>0) modifiers.extraShots = extraShots;
+    const lineItem = {
+      id: `${item.id}:${JSON.stringify(modifiers)}`,
+      name: item.name,
+      basePrice: item.price,
+      price: total,
+      unitPrice: total,
+      modifiers,
+      quantity: 1,
+    };
+    onAdd?.(lineItem);
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.content}>
+          <ScrollView>
+            <Text style={styles.title}>{item?.name}</Text>
+            {item?.desc && <Text style={styles.desc}>{item.desc}</Text>}
+            {item?.flags.alt && (
+              <View style={styles.optionSection}>
+                <Text style={styles.label}>Alt milk</Text>
+                <View style={styles.chipRow}>
+                  {options.altMilks.map(m => (
+                    <Pressable key={m} onPress={() => setAltMilk(m)} style={[styles.chip, altMilk===m && styles.chipSelected]}>
+                      <Text style={styles.chipText}>{m}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+              </View>
+            )}
+            {item?.flags.syrups && (
+              <View style={styles.optionSection}>
+                <Text style={styles.label}>Syrups</Text>
+                {options.syrups.map(opt => (
+                  <View key={opt.key} style={styles.stepRow}>
+                    <Text style={styles.stepLabel}>{opt.label}</Text>
+                    <View style={styles.stepCtrls}>
+                      <Pressable onPress={() => setSyrups(prev=>({ ...prev, [opt.key]: Math.max(0,(prev[opt.key]||0)-1) }))} style={styles.ctrlBtn}><Text style={styles.ctrlTxt}>-</Text></Pressable>
+                      <Text style={styles.stepCount}>{syrups[opt.key]||0}</Text>
+                      <Pressable onPress={() => setSyrups(prev=>({ ...prev, [opt.key]: (prev[opt.key]||0)+1 }))} style={styles.ctrlBtn}><Text style={styles.ctrlTxt}>+</Text></Pressable>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            )}
+            {item?.flags.coffee && (
+              <View style={styles.optionSection}>
+                <Text style={styles.label}>Coffee blend</Text>
+                <View style={styles.chipRow}>
+                  {options.coffeeBlends.map(opt => (
+                    <Pressable key={opt.key} onPress={() => setCoffeeBlend(opt.key)} style={[styles.chip, coffeeBlend===opt.key && styles.chipSelected]}>
+                      <Text style={styles.chipText}>{opt.label}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+              </View>
+            )}
+            {item?.flags.extra && (
+              <View style={styles.optionSection}>
+                <Text style={styles.label}>Extra shot</Text>
+                <View style={styles.stepCtrls}>
+                  <Pressable onPress={() => setExtraShots(Math.max(0,extraShots-1))} style={styles.ctrlBtn}><Text style={styles.ctrlTxt}>-</Text></Pressable>
+                  <Text style={styles.stepCount}>{extraShots}</Text>
+                  <Pressable onPress={() => setExtraShots(extraShots+1)} style={styles.ctrlBtn}><Text style={styles.ctrlTxt}>+</Text></Pressable>
+                </View>
+              </View>
+            )}
+          </ScrollView>
+          <Text style={styles.price}>£{total.toFixed(2)}</Text>
+          <Pressable style={styles.addBtn} onPress={add}><Text style={styles.addTxt}>Add to cart</Text></Pressable>
+          <Pressable style={styles.closeBtn} onPress={onClose}><Text style={styles.closeTxt}>Close</Text></Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay:{ flex:1, backgroundColor:'rgba(0,0,0,0.5)', alignItems:'center', justifyContent:'center' },
+  content:{ backgroundColor:palette.paper, borderRadius:14, padding:20, width:'80%', maxHeight:'90%' },
+  title:{ fontSize:20, color:palette.coffee, fontFamily:'Fraunces_700Bold', marginBottom:8 },
+  desc:{ color:palette.coffee, fontFamily:'Fraunces_600SemiBold', marginBottom:12 },
+  optionSection:{ marginBottom:16 },
+  label:{ color:palette.coffee, fontFamily:'Fraunces_600SemiBold', marginBottom:8 },
+  chipRow:{ flexDirection:'row', flexWrap:'wrap', gap:8 },
+  chip:{ paddingVertical:6, paddingHorizontal:10, borderRadius:16, backgroundColor:palette.cream, marginRight:8, marginBottom:8 },
+  chipSelected:{ backgroundColor:palette.coffee },
+  chipText:{ color:palette.coffee },
+  stepRow:{ flexDirection:'row', justifyContent:'space-between', alignItems:'center', marginBottom:8 },
+  stepLabel:{ color:palette.coffee, fontFamily:'Fraunces_600SemiBold' },
+  stepCtrls:{ flexDirection:'row', alignItems:'center' },
+  ctrlBtn:{ paddingHorizontal:12, paddingVertical:6, backgroundColor:palette.cream, borderRadius:8 },
+  ctrlTxt:{ fontSize:18, color:palette.coffee },
+  stepCount:{ width:24, textAlign:'center', fontSize:16, color:palette.coffee },
+  price:{ fontSize:18, color:palette.coffee, fontFamily:'Fraunces_700Bold', marginBottom:12, textAlign:'center' },
+  addBtn:{ backgroundColor:palette.coffee, padding:12, borderRadius:8, alignItems:'center', marginBottom:8 },
+  addTxt:{ color:'#fff', fontFamily:'Fraunces_700Bold' },
+  closeBtn:{ alignItems:'center', padding:8 },
+  closeTxt:{ color:palette.coffee, fontFamily:'Fraunces_600SemiBold' },
+});
+

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -70,8 +70,27 @@ export default function CartScreen({ navigation }) {
           <Text style={styles.itemName}>{item.name}</Text>
           <Text style={styles.itemPrice}>£{(item.price * item.quantity).toFixed(2)}</Text>
         </View>
+        {(() => {
+          const parts = [];
+          const mods = item.modifiers || {};
+          if (mods.altMilk) parts.push(mods.altMilk);
+          if (mods.syrups && mods.syrups.length) {
+            const counts = {};
+            mods.syrups.forEach((s) => { counts[s] = (counts[s] || 0) + 1; });
+            for (const [label, count] of Object.entries(counts)) {
+              parts.push(count > 1 ? `${count}× ${label}` : label);
+            }
+          }
+          if (mods.coffeeBlend) parts.push(mods.coffeeBlend);
+          if (typeof mods.extraShots === 'number' && mods.extraShots > 0) {
+            parts.push(`+${mods.extraShots} shot${mods.extraShots > 1 ? 's' : ''}`);
+          }
+          return parts.length ? (
+            <Text style={styles.itemSubtitle}>{parts.join(' · ')}</Text>
+          ) : null;
+        })()}
 
-        <View style={[styles.rowBetween, { marginTop: 10 }]}>
+        <View style={[styles.rowBetween, { marginTop: 10 }]}> 
           <View style={styles.qtyControls}>
             <TouchableOpacity
               style={[styles.qtyBtn, styles.qtyBtnLeft]}
@@ -191,6 +210,12 @@ const styles = StyleSheet.create({
     fontFamily: 'Fraunces_700Bold',
     flexShrink: 1,
     paddingRight: 10,
+  },
+  itemSubtitle: {
+    fontSize: 12,
+    color: palette.clay,
+    fontFamily: 'Fraunces_600SemiBold',
+    marginTop: 4,
   },
 
   itemPrice: {

--- a/src/screens/MenuScreen.js
+++ b/src/screens/MenuScreen.js
@@ -1,6 +1,5 @@
 
 import React, { useEffect, useState, useCallback } from 'react';
-
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   View,
@@ -8,42 +7,34 @@ import {
   StyleSheet,
   FlatList,
   Pressable,
-  Modal,
-  Image,
   ScrollView,
   RefreshControl,
   Alert,
 } from 'react-native';
 import { palette } from '../design/theme';
-import { getMenuItems } from '../services/menu';
-import { getCachedMenuItems, setCachedMenuItems } from '../boot/preload';
+import { getMenuData } from '../services/menuData.js';
 import { useCart } from '../context/CartContext';
 import { supabase } from '../lib/supabase';
 import { useNavigation } from '@react-navigation/native';
+import MenuItemDetail from '../components/MenuItemDetail';
 
 export default function MenuScreen() {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
   const { addItem } = useCart();
 
-  const [items, setItems] = useState(globalThis.preloaded?.menuItems || []);
-
+  const [menu, setMenu] = useState(null);
   const [selected, setSelected] = useState(null);
-  const [shots, setShots] = useState(0);
   const [refreshing, setRefreshing] = useState(false);
 
-
   const refreshMenu = useCallback(async () => {
-    const data = await getMenuItems();
-    setItems(data);
-    globalThis.preloaded = globalThis.preloaded || {};
-    globalThis.preloaded.menuItems = data;
+    const data = await getMenuData();
+    setMenu(data);
   }, []);
 
-
   useEffect(() => {
-    if (items.length === 0) refreshMenu();
-  }, [items.length, refreshMenu]);
+    if (!menu) refreshMenu();
+  }, [menu, refreshMenu]);
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -51,13 +42,7 @@ export default function MenuScreen() {
     setRefreshing(false);
   }, [refreshMenu]);
 
-  const priceWithShots = () => {
-    if (!selected) return 0;
-    const shotPrice = selected?.options?.syrupShotPrice || selected?.options?.syrup_shot_price || 0;
-    return selected.base_price + shots * shotPrice;
-  };
-
-  const addToCart = async () => {
+  const onAddItem = async (lineItem) => {
     try {
       const { data } = await supabase?.auth?.getSession();
       if (!data?.session) {
@@ -84,28 +69,27 @@ export default function MenuScreen() {
       );
       return;
     }
-    addItem({ ...selected, shots, price: priceWithShots() });
+    addItem(lineItem);
     setSelected(null);
   };
 
   const renderItem = ({ item }) => (
-    <Pressable style={styles.itemCard} onPress={() => { setSelected(item); setShots(0); }}>
+    <Pressable style={styles.itemCard} onPress={() => setSelected(item)}>
       <Text style={styles.itemName}>{item.name}</Text>
-      <Text style={styles.itemPrice}>£{item.base_price?.toFixed(2)}</Text>
+      <Text style={styles.itemPrice}>£{item.price?.toFixed(2)}</Text>
     </Pressable>
   );
 
-  const coffeeItems = items.filter(i => i.category === 'coffee');
-  const pifItems = items.filter(i => i.category === 'pif');
-  const specialsItems = items.filter(i => i.category === 'specials');
-  const otherItems = items.filter(i => !['coffee', 'pif', 'specials'].includes(i.category));
+  const coffeeItems = menu?.itemsByCategory.coffee || [];
+  const pifItems = menu?.itemsByCategory.pif || [];
+  const specialsItems = menu?.itemsByCategory.specials || [];
+  const otherItems = menu?.itemsByCategory['not-coffee'] || [];
 
   return (
     <SafeAreaView style={styles.container} edges={['left','right']}>
       <View style={[styles.header, { paddingTop: insets.top }]}><Text style={styles.headerTitle}>Menu</Text></View>
 
       <ScrollView refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />} contentContainerStyle={styles.scroll}>
-
         {coffeeItems.length > 0 && (
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Coffee</Text>
@@ -159,30 +143,13 @@ export default function MenuScreen() {
           </View>
         )}
       </ScrollView>
-      <Modal visible={!!selected} transparent animationType="fade" onRequestClose={() => setSelected(null)}>
-        <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
-            {selected?.image && <Image source={{ uri: selected.image }} style={styles.modalImage} />}
-            <Text style={styles.modalTitle}>{selected?.name}</Text>
-            {selected?.description && <Text style={styles.modalDesc}>{selected.description}</Text>}
-            {['coffee', 'matcha'].includes(selected?.type) && (
-              <View style={styles.shotRow}>
-                <Text style={styles.shotLabel}>Syrup shots:</Text>
-                <View style={styles.shotCtrls}>
-                  <Pressable onPress={() => setShots(Math.max(0, shots - 1))} style={styles.ctrlBtn}><Text style={styles.ctrlTxt}>-</Text></Pressable>
-                  <Text style={styles.shotCount}>{shots}</Text>
-                  <Pressable onPress={() => setShots(shots + 1)} style={styles.ctrlBtn}><Text style={styles.ctrlTxt}>+</Text></Pressable>
-                </View>
-              </View>
-            )}
-
-            <Text style={styles.modalPrice}>£{priceWithShots().toFixed(2)}</Text>
-
-            <Pressable style={styles.addBtn} onPress={addToCart}><Text style={styles.addTxt}>Add to cart</Text></Pressable>
-            <Pressable style={styles.closeBtn} onPress={() => setSelected(null)}><Text style={styles.closeTxt}>Close</Text></Pressable>
-          </View>
-        </View>
-      </Modal>
+      <MenuItemDetail
+        item={selected}
+        options={menu?.options || { altMilks: [], syrups: [], coffeeBlends: [] }}
+        visible={!!selected}
+        onClose={() => setSelected(null)}
+        onAdd={onAddItem}
+      />
     </SafeAreaView>
   );
 }
@@ -229,21 +196,5 @@ const styles = StyleSheet.create({
     fontFamily: 'Fraunces_600SemiBold',
     textAlign: 'center',
   },
-  modalOverlay: { flex:1, backgroundColor:'rgba(0,0,0,0.5)', justifyContent:'center', alignItems:'center' },
-  modalContent: { backgroundColor: palette.paper, borderRadius: 14, padding:20, width:'80%' },
-  modalImage: { width: '100%', height: 150, borderRadius: 8, marginBottom: 12 },
-  modalTitle: { fontSize:20, color: palette.coffee, fontFamily:'Fraunces_700Bold', marginBottom:8 },
-  modalDesc: { color: palette.coffee, fontFamily:'Fraunces_600SemiBold', marginBottom:12 },
-  shotRow: { flexDirection:'row', alignItems:'center', marginBottom:12, justifyContent:'space-between' },
-  shotLabel: { color: palette.coffee, fontFamily:'Fraunces_600SemiBold' },
-  shotCtrls: { flexDirection:'row', alignItems:'center', gap:12 },
-  ctrlBtn: { paddingHorizontal:12, paddingVertical:6, backgroundColor: palette.cream, borderRadius:8 },
-  ctrlTxt: { fontSize:18, color: palette.coffee },
-  shotCount: { fontSize:16, color: palette.coffee },
-  modalPrice: { fontSize:18, color: palette.coffee, fontFamily:'Fraunces_700Bold', marginBottom:12 },
-  addBtn: { backgroundColor: palette.coffee, padding:12, borderRadius:8, alignItems:'center', marginBottom:8 },
-  addTxt: { color:'#fff', fontFamily:'Fraunces_700Bold' },
-  closeBtn: { alignItems:'center', padding:8 },
-  closeTxt: { color: palette.coffee, fontFamily:'Fraunces_600SemiBold' },
 });
 

--- a/src/services/__tests__/menuData.test.js
+++ b/src/services/__tests__/menuData.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { buildMenuData, computeItemTotal } from '../menuData.js';
+
+test('buildMenuData parses CMS map', () => {
+  const cms = {
+    'menu.coffee.latte': 'Latte',
+    'price.coffee.latte': '3.20',
+    'desc.coffee.latte': 'Delicious',
+    'alt.coffee.latte': '1',
+    'syrups-on.coffee.latte': '1',
+    'coffee-on.coffee.latte': '1',
+    'extra.coffee.latte': '1',
+    'syrups.vanilla': 'Vanilla',
+    'syrups.hazelnut': 'Hazelnut',
+    'coffee.single': 'Single Origin'
+  };
+  const data = buildMenuData(cms);
+  assert.strictEqual(data.itemsByCategory.coffee.length, 1);
+  const latte = data.itemsByCategory.coffee[0];
+  assert.strictEqual(latte.name, 'Latte');
+  assert.strictEqual(latte.price, 3.20);
+  assert.deepStrictEqual(latte.flags, { alt: true, extra: true, syrups: true, coffee: true });
+  assert.strictEqual(data.options.syrups.length, 2);
+  assert.strictEqual(data.options.coffeeBlends.length, 2); // house + single
+});
+
+test('computeItemTotal sums modifiers', () => {
+  const total = computeItemTotal(3.20, { syrupCount: 2, extraShots: 1 });
+  assert.strictEqual(total, 5.69);
+});
+

--- a/src/services/menuData.js
+++ b/src/services/menuData.js
@@ -1,0 +1,68 @@
+const ALT_MILKS = ['Skimmed','Semi-skimmed','Soy','Oat','Coconut','Almond','Lactose free'];
+const CATEGORIES = ['coffee','not-coffee','pif','specials'];
+
+export function buildMenuData(cmsMap = {}) {
+  const itemsByCategory = { 'coffee': [], 'not-coffee': [], 'pif': [], 'specials': [] };
+  const options = {
+    altMilks: ALT_MILKS.slice(),
+    syrups: [],
+    coffeeBlends: [{ key: 'house', label: 'House blend' }],
+  };
+
+  for (const [key, value] of Object.entries(cmsMap)) {
+    if (!value) continue;
+    if (key.startsWith('syrups.')) {
+      const suffix = key.split('.')[1];
+      options.syrups.push({ key: suffix, label: value });
+    } else if (key.startsWith('coffee.')) {
+      const suffix = key.split('.')[1];
+      options.coffeeBlends.push({ key: suffix, label: value });
+    }
+  }
+
+  for (const [key, value] of Object.entries(cmsMap)) {
+    if (!key.startsWith('menu.')) continue;
+    const parts = key.split('.');
+    if (parts.length < 3) continue;
+    const category = parts[1];
+    const suffix = parts.slice(2).join('.');
+    if (!CATEGORIES.includes(category)) continue;
+    if (!value) continue;
+    const base = `${category}.${suffix}`;
+    const priceRaw = cmsMap[`price.${base}`];
+    const price = parseFloat(priceRaw);
+    const desc = cmsMap[`desc.${base}`];
+    const img = cmsMap[`image.${base}`];
+    const item = {
+      id: `${category}:${suffix}`,
+      category,
+      suffix,
+      name: value,
+      price: isNaN(price) ? 0 : price,
+      desc: desc || undefined,
+      imageUri: img ? `data:image/*;base64,${img}` : undefined,
+      flags: {
+        alt: Boolean(cmsMap[`alt.${base}`]),
+        extra: Boolean(cmsMap[`extra.${base}`]),
+        syrups: Boolean(cmsMap[`syrups-on.${base}`] || cmsMap[`syrup-on.${base}`]),
+        coffee: Boolean(cmsMap[`coffee-on.${base}`]),
+      },
+    };
+    itemsByCategory[category].push(item);
+  }
+
+  return { itemsByCategory, options };
+}
+
+export async function getMenuData() {
+  const { getCMS } = await import('./cms.js');
+  const cms = await getCMS();
+  return buildMenuData(cms);
+}
+
+export function computeItemTotal(basePrice, { syrupCount = 0, extraShots = 0 } = {}) {
+  const base = parseFloat(basePrice) || 0;
+  const total = base + syrupCount * 0.5 + extraShots * 1.49;
+  return Number(total.toFixed(2));
+}
+


### PR DESCRIPTION
## Summary
- build `buildMenuData` to parse CMS menu keys, flags and option lists
- add `MenuItemDetail` component for alt milks, syrups, blends and extra shots
- show modifier summary in cart rows
- cover CMS parser and price calculations with node tests

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68af2e5e78908322967a7d072de8d9c1