### PR TITLE
feat: add receipt builder and POS test flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 .expo/
 .expo-shared/
 dist/
+__tests__/dist/
+build/
 .DS_Store
 
 # Native builds

--- a/__tests__/receipt.test.ts
+++ b/__tests__/receipt.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReceipt } from '../src/utils/receipt.js';
+
+test('buildReceipt totals with syrups and extra shots', () => {
+  const receipt = buildReceipt({
+    cartItems: [
+      {
+        id: 'latte',
+        name: 'Latte',
+        quantity: 1,
+        price: 3.2,
+        modifiers: {
+          altMilk: 'Oat',
+          syrups: ['Vanilla', 'Hazelnut'],
+          coffeeBlend: 'House blend',
+          extraShots: 1,
+        },
+      },
+    ],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+    rng: () => 0.4219,
+    uuidGenerator: () => 'test-uuid',
+  });
+  assert.equal(receipt.items[0].unitModifierTotal, 2.49);
+  assert.equal(receipt.items[0].unitFinalPrice, 5.69);
+  assert.equal(receipt.totals.subtotal, 5.69);
+  assert.equal(receipt.totals.discounts, 0);
+  assert.equal(receipt.totals.grandTotal, 5.69);
+});
+
+test('pickupCode is 5 digits', () => {
+  const receipt = buildReceipt({
+    cartItems: [],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+    rng: () => 0.1,
+    uuidGenerator: () => 'uuid2',
+  });
+  assert.match(receipt.pickupCode, /^\d{5}$/);
+});
+
+test('deterministic with fixed rng and uuid', () => {
+  const rng = () => 0.12345;
+  const uuid = () => 'fixed-uuid';
+  const r1 = buildReceipt({ cartItems: [], selectedTimeSlot: { start: new Date(0), end: new Date(600000) }, rng, uuidGenerator: uuid });
+  const r2 = buildReceipt({ cartItems: [], selectedTimeSlot: { start: new Date(0), end: new Date(600000) }, rng, uuidGenerator: uuid });
+  assert.equal(r1.pickupCode, r2.pickupCode);
+  assert.equal(r1.orderId, r2.orderId);
+});
+
+test('currency rounds to 2dp', () => {
+  const receipt = buildReceipt({
+    cartItems: [{ id: 't', name: 'Test', quantity: 1, price: 1.335 }],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+    rng: () => 0.2,
+    uuidGenerator: () => 'uuid3',
+  });
+  assert.equal(receipt.items[0].unitBasePrice, 1.34);
+  assert.equal(receipt.items[0].unitFinalPrice, 1.34);
+  assert.equal(receipt.totals.subtotal, 1.34);
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "mock": "node generatePasses.js && expo start",
     "grant-rewards": "node scripts/grant-rewards.js",
     "reset-rewards": "node scripts/reset-rewards.js",
-    "sync-menu-items": "node scripts/sync-menu-items.js"
+    "sync-menu-items": "node scripts/sync-menu-items.js",
+    "test": "tsc __tests__/receipt.test.ts src/utils/receipt.ts --module node16 --target ES2020 --outDir build && node --test build/__tests__/receipt.test.js"
   },
   "dependencies": {
     "@expo-google-fonts/fraunces": "^0.4.0",

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -1,10 +1,11 @@
 import React, { useContext, useMemo, useState } from 'react';
-import { View, Text, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, FlatList, StyleSheet, TouchableOpacity, Alert } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Swipeable } from 'react-native-gesture-handler';
 import { useTabBarHeight } from '../navigation/TabBarHeightContext';
 import { CartContext } from '../context/CartContext';
 import { palette } from '../design/theme';
+import { buildReceipt, sendReceiptToPOS } from '../utils/receipt';
 
 export default function CartScreen({ navigation }) {
   const insets = useSafeAreaInsets();
@@ -21,6 +22,7 @@ export default function CartScreen({ navigation }) {
     removeItem,
     updateQuantity,
     clearItem, // some apps name it like this
+    clear,
   } = cart;
 
   const [timeSlot, setTimeSlot] = useState(null);
@@ -50,10 +52,14 @@ export default function CartScreen({ navigation }) {
     // If you already have a screen/modal, navigate there:
     // navigation?.navigate?.('PickTimeSlot', { onSelect: (slot) => setTimeSlot(slot) });
     // Minimal inline fallback for now:
-    const now = new Date();
-    const mm = String(now.getMinutes()).padStart(2, '0');
-    const hh = String(now.getHours()).padStart(2, '0');
-    setTimeSlot(`Today ${hh}:${mm}`);
+    const start = new Date();
+    const end = new Date(start.getTime() + 10 * 60 * 1000);
+    setTimeSlot({ start, end });
+  };
+
+  const formatSlotLabel = (slot) => {
+    const pad = (n) => String(n).padStart(2, '0');
+    return `Today ${pad(slot.start.getHours())}:${pad(slot.start.getMinutes())}`;
   };
 
   const renderItem = ({ item }) => (
@@ -148,15 +154,26 @@ export default function CartScreen({ navigation }) {
 
         <View style={styles.footerButtonsRow}>
           <TouchableOpacity style={styles.slotBtn} onPress={onPickTimeSlot}>
-            <Text style={styles.slotBtnText}>{timeSlot ? timeSlot : 'Pick time slot'}</Text>
+            <Text style={styles.slotBtnText}>{timeSlot ? formatSlotLabel(timeSlot) : 'Pick time slot'}</Text>
           </TouchableOpacity>
 
           <TouchableOpacity
             style={[styles.applePayBtn, !timeSlot && styles.applePayBtnDisabled]}
             disabled={!timeSlot}
-            onPress={() => {
+            onPress={async () => {
               if (!timeSlot) return;
-              // hook up your Apple Pay flow here
+              const receipt = buildReceipt({
+                cartItems: items,
+                selectedTimeSlot: timeSlot,
+                customer: null,
+                pifContribution: 0,
+                vouchersApplied: 0,
+                paymentMethod: 'test',
+              });
+              await sendReceiptToPOS(receipt);
+              Alert.alert('Order placed', `Pickup code: ${receipt.pickupCode}`);
+              clear?.();
+              setTimeSlot(null);
             }}
           >
             <Text style={styles.applePayText}> Pay</Text>

--- a/src/utils/receipt.ts
+++ b/src/utils/receipt.ts
@@ -1,0 +1,219 @@
+
+export type ReceiptItemModifier =
+  | { type: 'altMilk'; label: string; priceDelta: number }
+  | { type: 'syrup'; label: string; priceDelta: number }
+  | { type: 'coffeeBlend'; label: string; priceDelta: number }
+  | { type: 'extraShot'; count: number; priceDelta: number };
+
+export type ReceiptItem = {
+  id: string;
+  name: string;
+  quantity: number;
+  unitBasePrice: number;
+  unitModifierTotal: number;
+  unitFinalPrice: number;
+  lineTotal: number;
+  modifiers: ReceiptItemModifier[];
+  notes?: string;
+};
+
+export type ReceiptTotals = {
+  currency: 'GBP';
+  subtotal: number;
+  discounts: number;
+  pifContribution: number;
+  tax: number;
+  grandTotal: number;
+};
+
+export type Receipt = {
+  orderId: string;
+  pickupCode: string;
+  createdAt: string;
+  channel: 'click_and_collect';
+  paymentMethod: 'apple_pay' | 'card' | 'cash' | 'test';
+  customer?: { id?: string; email?: string };
+  timeSlot: { startISO: string; endISO: string };
+  items: ReceiptItem[];
+  totals: ReceiptTotals;
+  vouchersRedeemed?: number;
+  freeDrinksUsed?: number;
+  meta?: Record<string, any>;
+};
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function formatISO(d: Date): string {
+  return d.toISOString();
+}
+
+export function buildReceipt({
+  cartItems,
+  selectedTimeSlot,
+  customer,
+  pifContribution = 0,
+  vouchersApplied = 0,
+  paymentMethod = 'test',
+  rng = Math.random,
+  uuidGenerator = () => (globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : Math.random().toString(36).slice(2)),
+}: {
+  cartItems: Array<{
+    id: string;
+    name: string;
+    quantity: number;
+    price: number;
+    modifiers?: {
+      altMilk?: string;
+      syrups?: string[];
+      coffeeBlend?: string;
+      extraShots?: number;
+    };
+    notes?: string;
+  }>;
+  selectedTimeSlot: { start: Date; end: Date };
+  customer?: { id?: string; email?: string } | null;
+  pifContribution?: number;
+  vouchersApplied?: number;
+  paymentMethod?: 'apple_pay' | 'card' | 'cash' | 'test';
+  rng?: () => number;
+  uuidGenerator?: () => string;
+}): Receipt {
+  const items: ReceiptItem[] = cartItems.map((item) => {
+    const mods: ReceiptItemModifier[] = [];
+    let unitModifierTotal = 0;
+    const m = item.modifiers || {};
+    if (m.altMilk) {
+      mods.push({ type: 'altMilk', label: m.altMilk, priceDelta: 0 });
+    }
+    if (m.syrups) {
+      m.syrups.forEach((s) => {
+        mods.push({ type: 'syrup', label: s, priceDelta: 0.5 });
+      });
+      unitModifierTotal += 0.5 * m.syrups.length;
+    }
+    if (m.coffeeBlend) {
+      mods.push({ type: 'coffeeBlend', label: m.coffeeBlend, priceDelta: 0 });
+    }
+    if (typeof m.extraShots === 'number' && m.extraShots > 0) {
+      mods.push({ type: 'extraShot', count: m.extraShots, priceDelta: 1.49 });
+      unitModifierTotal += 1.49 * m.extraShots;
+    }
+    unitModifierTotal = round2(unitModifierTotal);
+    const unitBasePrice = round2(item.price);
+    const unitFinalPrice = round2(unitBasePrice + unitModifierTotal);
+    const lineTotal = round2(unitFinalPrice * item.quantity);
+    return {
+      id: item.id,
+      name: item.name,
+      quantity: item.quantity,
+      unitBasePrice,
+      unitModifierTotal,
+      unitFinalPrice,
+      lineTotal,
+      modifiers: mods,
+      notes: item.notes,
+    };
+  });
+
+  const subtotal = round2(items.reduce((sum, i) => sum + i.lineTotal, 0));
+  let discounts = 0;
+  let vouchersLeft = vouchersApplied;
+  for (const item of items) {
+    if (vouchersLeft <= 0) break;
+    const redeem = Math.min(vouchersLeft, item.quantity);
+    discounts += redeem * item.unitBasePrice;
+    vouchersLeft -= redeem;
+  }
+  discounts = round2(discounts);
+  const tax = 0;
+  const pif = round2(pifContribution);
+  const grandTotal = round2(subtotal - discounts + pif + tax);
+
+  const orderId = uuidGenerator();
+  const pickupCode = String(Math.floor(rng() * 100000)).padStart(5, '0');
+  const createdAt = formatISO(new Date());
+
+  return {
+    orderId,
+    pickupCode,
+    createdAt,
+    channel: 'click_and_collect',
+    paymentMethod,
+    customer: customer || undefined,
+    timeSlot: {
+      startISO: formatISO(selectedTimeSlot.start),
+      endISO: formatISO(selectedTimeSlot.end),
+    },
+    items,
+    totals: {
+      currency: 'GBP',
+      subtotal,
+      discounts,
+      pifContribution: pif,
+      tax,
+      grandTotal,
+    },
+    vouchersRedeemed: vouchersApplied || undefined,
+  };
+}
+
+function formatTimeRange(startISO: string, endISO: string): string {
+  const start = new Date(startISO);
+  const end = new Date(endISO);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${start.getFullYear()}-${pad(start.getMonth() + 1)}-${pad(start.getDate())} ` +
+    `${pad(start.getHours())}:${pad(start.getMinutes())}–${pad(end.getHours())}:${pad(end.getMinutes())}`;
+}
+
+export function printReceiptToConsole(receipt: Receipt): void {
+  const lines: string[] = [];
+  lines.push('=== RECEIPT (TEST LOG) ===');
+  lines.push('Ruminate — Click & Collect');
+  lines.push(`Order: ${receipt.orderId}   Code: ${receipt.pickupCode}`);
+  lines.push(`When: ${formatTimeRange(receipt.timeSlot.startISO, receipt.timeSlot.endISO)}`);
+  lines.push('');
+  receipt.items.forEach((item) => {
+    lines.push(`${item.quantity} × ${item.name}  £${item.unitFinalPrice.toFixed(2)}`);
+    item.modifiers.forEach((m) => {
+      if (m.type === 'altMilk') lines.push(`   • ${m.label}`);
+      if (m.type === 'syrup') lines.push(`   • ${m.label} (+£${m.priceDelta.toFixed(2)})`);
+      if (m.type === 'coffeeBlend') lines.push(`   • ${m.label}`);
+      if (m.type === 'extraShot') lines.push(`   • +${m.count} shot${m.count > 1 ? 's' : ''} (+£${(m.priceDelta * m.count).toFixed(2)})`);
+    });
+    lines.push(`   = £${item.lineTotal.toFixed(2)}`);
+    lines.push('');
+  });
+  lines.push(`Subtotal: £${receipt.totals.subtotal.toFixed(2)}`);
+  if (receipt.vouchersRedeemed) {
+    lines.push(`Vouchers used: ${receipt.vouchersRedeemed} (−£${receipt.totals.discounts.toFixed(2)})`);
+  }
+  if (receipt.totals.pifContribution) {
+    lines.push(`PIF: £${receipt.totals.pifContribution.toFixed(2)}`);
+  }
+  lines.push(`Tax: £${receipt.totals.tax.toFixed(2)}`);
+  lines.push(`TOTAL: £${receipt.totals.grandTotal.toFixed(2)}`);
+  console.log(lines.join('\n'));
+  console.log('=== RECEIPT JSON ===');
+  console.log(JSON.stringify(receipt, null, 2));
+}
+
+export async function sendReceiptToPOS(receipt: Receipt): Promise<void> {
+  const endpoint = process.env.EXPO_PUBLIC_POS_ENDPOINT;
+  if (!endpoint) {
+    printReceiptToConsole(receipt);
+    return;
+  }
+  try {
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(receipt),
+    });
+  } catch (err) {
+    console.error('Failed to send receipt to POS', err);
+    printReceiptToConsole(receipt);
+  }
+}
+


### PR DESCRIPTION
## Summary
- buildReceipt converts cart + time slot into structured receipt with modifiers, totals and random identifiers
- add console printer and POS shim; wire CartScreen pay flow to generate and send receipt then clear cart
- add unit tests for receipt math, pickup code, determinism and currency rounding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af3248918c8322862fc096cad68d03