### PR TITLE
fix(config): add functions URL resolver and use in getMyStats\n\n- Ad…

### DIFF
--- a/src/components/SplashGate.tsx
+++ b/src/components/SplashGate.tsx
@@ -33,7 +33,8 @@ export default function SplashGate() {
 
   const [visible, setVisible] = useState(true);
   const [idx, setIdx] = useState(0);
-  const opacity = useRef(new Animated.Value(1)).current;
+  const opacity = useRef(new Animated.Value(1)).current; // rotating status line
+  const gateOpacity = useRef(new Animated.Value(1)).current; // whole splash fade-out
 
 
   useEffect(() => {
@@ -43,10 +44,16 @@ export default function SplashGate() {
     preloadMenuItems().finally(() => markLoaded('cms'));
 
     const unsub = subscribe((st) => {
-      if (st.auth && st.stamps && st.cms) setVisible(false);
+      if (st.auth && st.stamps && st.cms) {
+        Animated.timing(gateOpacity, { toValue: 0, duration: FADE_MS, useNativeDriver: true })
+          .start(() => setVisible(false));
+      }
     });
 
-    const tmr = setTimeout(() => setVisible(false), HARD_TIMEOUT_MS);
+    const tmr = setTimeout(() => {
+      Animated.timing(gateOpacity, { toValue: 0, duration: FADE_MS, useNativeDriver: true })
+        .start(() => setVisible(false));
+    }, HARD_TIMEOUT_MS);
 
     const rot = setInterval(() => {
       Animated.timing(opacity, { toValue: 0, duration: FADE_MS, useNativeDriver: true }).start(() => {
@@ -58,7 +65,10 @@ export default function SplashGate() {
 
     // If all are already ready (e.g. dev reload), hide immediately
     const s = getLoadingState();
-    if (s.auth && s.stamps && s.cms) setTimeout(() => setVisible(false), 0);
+    if (s.auth && s.stamps && s.cms) setTimeout(() => {
+      Animated.timing(gateOpacity, { toValue: 0, duration: FADE_MS, useNativeDriver: true })
+        .start(() => setVisible(false));
+    }, 0);
 
     return () => {
       unsub?.();
@@ -71,10 +81,12 @@ export default function SplashGate() {
 
   return (
 
-    <SafeAreaView style={styles.wrap} edges={["top", "bottom"]}>
-      <Image source={logo} style={styles.logo} />
-      <Animated.Text style={[styles.line, { opacity }]}>{LINES[idx]}</Animated.Text>
-    </SafeAreaView>
+    <Animated.View style={[styles.wrap, { opacity: gateOpacity }]}>
+      <SafeAreaView style={styles.sa} edges={["top", "bottom"]}>
+        <Image source={logo} style={styles.logo} />
+        <Animated.Text style={[styles.line, { opacity }]}>{LINES[idx]}</Animated.Text>
+      </SafeAreaView>
+    </Animated.View>
 
   );
 }
@@ -86,10 +98,13 @@ const styles = StyleSheet.create({
     left: 0, right: 0, top: 0, bottom: 0,
 
     backgroundColor: palette.cream,
-
+  },
+  sa: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 24,
+    backgroundColor: 'transparent',
   },
   logo: { width: 156, height: 156, resizeMode: 'contain', marginBottom: 16 },
   line: {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,28 @@
+import Constants from 'expo-constants';
+
+// Prefer public Expo envs; fall back to app config extras; then derive from Supabase URL; finally a safe default.
+const fromEnv = (process as any)?.env?.EXPO_PUBLIC_FUNCTIONS_URL as string | undefined;
+
+const supabaseUrl = (
+  (process as any)?.env?.EXPO_PUBLIC_SUPABASE_URL ||
+  (Constants as any)?.expoConfig?.extra?.EXPO_PUBLIC_SUPABASE_URL ||
+  (Constants as any)?.manifest?.extra?.EXPO_PUBLIC_SUPABASE_URL ||
+  (Constants as any)?.manifestExtra?.EXPO_PUBLIC_SUPABASE_URL
+) as string | undefined;
+
+const fromSupabaseUrl = supabaseUrl ? `${supabaseUrl.replace(/\/$/, '')}/functions/v1` : undefined;
+
+// Last-resort default; replace with your project or remove to force env-driven config.
+const DEFAULT_FUNCTIONS_URL = 'https://eamewialuovzguldcdcf.functions.supabase.co';
+
+export function getFunctionsUrl(): string {
+  return (
+    fromEnv ||
+    (Constants as any)?.expoConfig?.extra?.EXPO_PUBLIC_FUNCTIONS_URL ||
+    (Constants as any)?.manifest?.extra?.EXPO_PUBLIC_FUNCTIONS_URL ||
+    (Constants as any)?.manifestExtra?.EXPO_PUBLIC_FUNCTIONS_URL ||
+    fromSupabaseUrl ||
+    DEFAULT_FUNCTIONS_URL
+  );
+}
+

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -1,28 +1,12 @@
 import { supabase } from '../lib/supabase';
-import Constants from 'expo-constants';
+import { getFunctionsUrl } from '../lib/config';
 
 export async function getMyStats() {
   try {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.access_token) return { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
 
-    const extras = Constants?.expoConfig?.extra || Constants?.manifest?.extra || Constants?.manifestExtra || {};
-    const supabaseUrl =
-      process.env.EXPO_PUBLIC_SUPABASE_URL ||
-      process.env.SUPABASE_URL ||
-      extras.EXPO_PUBLIC_SUPABASE_URL ||
-      extras.SUPABASE_URL ||
-      '';
-    const base =
-      process.env.EXPO_PUBLIC_FUNCTIONS_URL ||
-      process.env.FUNCTIONS_URL ||
-      extras.EXPO_PUBLIC_FUNCTIONS_URL ||
-      extras.FUNCTIONS_URL ||
-      (supabaseUrl ? `${supabaseUrl}/functions/v1` : '');
-    if (!base) {
-      console.error('getMyStats failed: missing functions URL');
-      return { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
-    }
+    const base = getFunctionsUrl();
     const url = `${base.replace(/\/$/, '')}/me-stats`;
 
     const res = await fetch(url, {


### PR DESCRIPTION
…d src/lib/config.ts with getFunctionsUrl() resolving from Expo public envs, Expo extra, derived from Supabase URL, with safe fallback.\n- Use in src/services/stats.js to stop "missing functions URL" errors.\n\nfix(splash): fade out gate from effects/callbacks only\n\n- Animate SplashGate hide and avoid state updates during insertion.\n- Use animation completion handlers and effect timers only.