### PR TITLE
feat: add receipt builder and POS test flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 .expo/
 .expo-shared/
 dist/
+__tests__/dist/
+build/
 .DS_Store
 
 # Native builds

--- a/__tests__/loyalty.test.ts
+++ b/__tests__/loyalty.test.ts
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { countStampsFromReceipt } from '../src/utils/loyalty.js';
+import type { Receipt } from '../src/utils/receipt.js';
+
+test('countStampsFromReceipt sums quantities ignoring modifiers', () => {
+  const receipt: Receipt = {
+    orderId: 'o1',
+    pickupCode: '12345',
+    createdAt: new Date().toISOString(),
+    channel: 'click_and_collect',
+    paymentMethod: 'test',
+    customer: undefined,
+    timeSlot: { startISO: '', endISO: '' },
+    items: [
+      {
+        id: 'coffee:latte',
+        name: 'Latte',
+        quantity: 1,
+        unitBasePrice: 0,
+        unitModifierTotal: 0.5,
+        unitFinalPrice: 0,
+        lineTotal: 0,
+        modifiers: [
+          { type: 'syrup', label: 'Vanilla', priceDelta: 0.5 },
+          { type: 'extraShot', count: 1, priceDelta: 1.49 }
+        ],
+      },
+      {
+        id: 'coffee:mocha',
+        name: 'Mocha',
+        quantity: 2,
+        unitBasePrice: 0,
+        unitModifierTotal: 0,
+        unitFinalPrice: 0,
+        lineTotal: 0,
+        modifiers: [],
+      },
+      {
+        id: 'food:sandwich',
+        name: 'Sandwich',
+        quantity: 1,
+        unitBasePrice: 0,
+        unitModifierTotal: 0,
+        unitFinalPrice: 0,
+        lineTotal: 0,
+        modifiers: [{ type: 'altMilk', label: 'Oat', priceDelta: 0 }],
+      },
+    ],
+    totals: { currency: 'GBP', subtotal: 0, discounts: 0, pifContribution: 0, tax: 0, grandTotal: 0 },
+  };
+  assert.equal(countStampsFromReceipt(receipt), 4);
+});
+
+test('countStampsFromReceipt example receipt returns 3', () => {
+  const receipt: Receipt = {
+    orderId: 'o2',
+    pickupCode: '22222',
+    createdAt: new Date().toISOString(),
+    channel: 'click_and_collect',
+    paymentMethod: 'test',
+    customer: undefined,
+    timeSlot: { startISO: '', endISO: '' },
+    items: [
+      { id: 'coffee:latte', name: 'Latte', quantity: 1, unitBasePrice: 0, unitModifierTotal: 0, unitFinalPrice: 0, lineTotal: 0, modifiers: [] },
+      { id: 'drink:pif', name: 'Pay It Forward', quantity: 1, unitBasePrice: 0, unitModifierTotal: 0, unitFinalPrice: 0, lineTotal: 0, modifiers: [] },
+      { id: 'food:sandwich', name: 'Sandwich', quantity: 1, unitBasePrice: 0, unitModifierTotal: 0, unitFinalPrice: 0, lineTotal: 0, modifiers: [] },
+    ],
+    totals: { currency: 'GBP', subtotal: 0, discounts: 0, pifContribution: 0, tax: 0, grandTotal: 0 },
+  };
+  assert.equal(countStampsFromReceipt(receipt), 3);
+});
+
+test('awardStamps rollover with idempotency', () => {
+  const profile = { stamps: 7, freebies: 0 };
+  const ledger = new Set<string>();
+  function award(order: string, add: number) {
+    if (add <= 0 || ledger.has(order)) return;
+    ledger.add(order);
+    const total = profile.stamps + add;
+    profile.freebies += Math.floor(total / 8);
+    profile.stamps = total % 8;
+  }
+  award('order1', 3);
+  assert.deepEqual(profile, { stamps: 2, freebies: 1 });
+  award('order1', 3);
+  assert.deepEqual(profile, { stamps: 2, freebies: 1 });
+});

--- a/__tests__/receipt.test.ts
+++ b/__tests__/receipt.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReceipt } from '../src/utils/receipt.js';
+
+test('buildReceipt totals with syrups and extra shots', () => {
+  const receipt = buildReceipt({
+    cartItems: [
+      {
+        id: 'latte',
+        name: 'Latte',
+        quantity: 1,
+        price: 3.2,
+        modifiers: {
+          altMilk: 'Oat',
+          syrups: ['Vanilla', 'Hazelnut'],
+          coffeeBlend: 'House blend',
+          extraShots: 1,
+        },
+      },
+    ],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+    rng: () => 0.4219,
+    uuidGenerator: () => 'test-uuid',
+  });
+  assert.equal(receipt.items[0].unitModifierTotal, 2.49);
+  assert.equal(receipt.items[0].unitFinalPrice, 5.69);
+  assert.equal(receipt.totals.subtotal, 5.69);
+  assert.equal(receipt.totals.discounts, 0);
+  assert.equal(receipt.totals.grandTotal, 5.69);
+});
+
+test('pickupCode is 5 digits', () => {
+  const receipt = buildReceipt({
+    cartItems: [],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+    rng: () => 0.1,
+    uuidGenerator: () => 'uuid2',
+  });
+  assert.match(receipt.pickupCode, /^\d{5}$/);
+});
+
+test('deterministic with fixed rng and uuid', () => {
+  const rng = () => 0.12345;
+  const uuid = () => 'fixed-uuid';
+  const r1 = buildReceipt({ cartItems: [], selectedTimeSlot: { start: new Date(0), end: new Date(600000) }, rng, uuidGenerator: uuid });
+  const r2 = buildReceipt({ cartItems: [], selectedTimeSlot: { start: new Date(0), end: new Date(600000) }, rng, uuidGenerator: uuid });
+  assert.equal(r1.pickupCode, r2.pickupCode);
+  assert.equal(r1.orderId, r2.orderId);
+});
+
+test('currency rounds to 2dp', () => {
+  const receipt = buildReceipt({
+    cartItems: [{ id: 't', name: 'Test', quantity: 1, price: 1.335 }],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+    rng: () => 0.2,
+    uuidGenerator: () => 'uuid3',
+  });
+  assert.equal(receipt.items[0].unitBasePrice, 1.34);
+  assert.equal(receipt.items[0].unitFinalPrice, 1.34);
+  assert.equal(receipt.totals.subtotal, 1.34);
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "mock": "node generatePasses.js && expo start",
     "grant-rewards": "node scripts/grant-rewards.js",
     "reset-rewards": "node scripts/reset-rewards.js",
-    "sync-menu-items": "node scripts/sync-menu-items.js"
+    "sync-menu-items": "node scripts/sync-menu-items.js",
+    "test": "tsc __tests__/receipt.test.ts __tests__/loyalty.test.ts src/utils/receipt.ts src/utils/loyalty.ts --module node16 --target ES2020 --outDir build && node --test build/__tests__/receipt.test.js build/__tests__/loyalty.test.js"
   },
   "dependencies": {
     "@expo-google-fonts/fraunces": "^0.4.0",

--- a/src/hooks/useHasOrders.js
+++ b/src/hooks/useHasOrders.js
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import { fetchUserOrders, subscribeUserOrders, onLocalOrdersChange } from '../services/orders';
+
+/**
+ * Track whether the current user has any orders.
+ */
+export default function useHasOrders() {
+  const [hasOrders, setHasOrders] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      try {
+        const data = await fetchUserOrders();
+        if (active) setHasOrders((data?.length || 0) > 0);
+      } catch {}
+    };
+
+    load();
+    const offRt = subscribeUserOrders(load);
+    const offLocal = onLocalOrdersChange(load);
+    return () => {
+      active = false;
+      try { offRt?.(); } catch {}
+      try { offLocal?.(); } catch {}
+    };
+  }, []);
+
+  return hasOrders;
+}

--- a/src/navigation/Router.js
+++ b/src/navigation/Router.js
@@ -8,6 +8,7 @@ import MembershipStartScreen from '../screens/MembershipStartScreen';
 import LoyaltyCardCreateScreen from '../screens/LoyaltyCardCreateScreen';
 import ManageSubscriptionScreen from '../screens/ManageSubscriptionScreen';
 import AccountDetailsScreen from '../screens/AccountDetailsScreen';
+import OrderDetailScreen from '../screens/OrderDetailScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -30,6 +31,7 @@ export default function Router() {
         <Stack.Screen name="AccountDetails" component={AccountDetailsScreen} />
         <Stack.Screen name="LoyaltyCardCreate" component={LoyaltyCardCreateScreen} />
         <Stack.Screen name="Community" component={CommunityScreen} />
+        <Stack.Screen name="OrderDetail" component={OrderDetailScreen} options={{ headerShown: true, title: 'Order' }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/navigation/SwipeTabs.js
+++ b/src/navigation/SwipeTabs.js
@@ -16,6 +16,8 @@ import { supabase } from '../lib/supabase';
 import CartScreen from '../screens/CartScreen';
 import { CartContext } from '../context/CartContext';
 import { TabBarHeightContext } from './TabBarHeightContext';
+import OrdersScreen from '../screens/OrdersScreen';
+import useHasOrders from '../hooks/useHasOrders';
 
 const Tab = createMaterialTopTabNavigator();
 
@@ -67,6 +69,7 @@ export default function SwipeTabs() {
   const [signedIn, setSignedIn] = useState(false);
   const { items } = useContext(CartContext);
   const [tabBarHeight, setTabBarHeight] = useState(0);
+  const hasOrders = useHasOrders();
 
   useEffect(() => {
     let active = true;
@@ -118,6 +121,13 @@ export default function SwipeTabs() {
         component={CommunityScreen}
         options={{ title: 'Community', tabBarIcon: ({ color }) => <Ionicons name="people-outline" size={22} color={color} /> }}
       />
+      {hasOrders && (
+        <Tab.Screen
+          name="Orders"
+          component={OrdersScreen}
+          options={{ title: 'Orders', tabBarIcon: ({ color }) => <Ionicons name="receipt-outline" size={22} color={color} /> }}
+        />
+      )}
       {items.length > 0 && (
         <Tab.Screen
           name="Cart"

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -1,13 +1,19 @@
 import React, { useContext, useMemo, useState } from 'react';
-import { View, Text, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, FlatList, StyleSheet, TouchableOpacity, Alert } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Swipeable } from 'react-native-gesture-handler';
 import { useTabBarHeight } from '../navigation/TabBarHeightContext';
 import { CartContext } from '../context/CartContext';
 import { palette } from '../design/theme';
+import { buildReceipt, sendReceiptToPOS } from '../utils/receipt';
+import { saveReceiptForUser } from '../services/orders';
+import { supabase } from '../lib/supabase';
+import { countStampsFromReceipt } from '../utils/loyalty';
+import { useStats } from '../hooks/useStats';
 
 export default function CartScreen({ navigation }) {
   const insets = useSafeAreaInsets();
+  const { refreshStats } = useStats();
 
   const tabBarHeight = useTabBarHeight();
   // Be defensive about what's available in CartContext
@@ -21,6 +27,7 @@ export default function CartScreen({ navigation }) {
     removeItem,
     updateQuantity,
     clearItem, // some apps name it like this
+    clear,
   } = cart;
 
   const [timeSlot, setTimeSlot] = useState(null);
@@ -50,10 +57,14 @@ export default function CartScreen({ navigation }) {
     // If you already have a screen/modal, navigate there:
     // navigation?.navigate?.('PickTimeSlot', { onSelect: (slot) => setTimeSlot(slot) });
     // Minimal inline fallback for now:
-    const now = new Date();
-    const mm = String(now.getMinutes()).padStart(2, '0');
-    const hh = String(now.getHours()).padStart(2, '0');
-    setTimeSlot(`Today ${hh}:${mm}`);
+    const start = new Date();
+    const end = new Date(start.getTime() + 10 * 60 * 1000);
+    setTimeSlot({ start, end });
+  };
+
+  const formatSlotLabel = (slot) => {
+    const pad = (n) => String(n).padStart(2, '0');
+    return `Today ${pad(slot.start.getHours())}:${pad(slot.start.getMinutes())}`;
   };
 
   const renderItem = ({ item }) => (
@@ -148,15 +159,43 @@ export default function CartScreen({ navigation }) {
 
         <View style={styles.footerButtonsRow}>
           <TouchableOpacity style={styles.slotBtn} onPress={onPickTimeSlot}>
-            <Text style={styles.slotBtnText}>{timeSlot ? timeSlot : 'Pick time slot'}</Text>
+            <Text style={styles.slotBtnText}>{timeSlot ? formatSlotLabel(timeSlot) : 'Pick time slot'}</Text>
           </TouchableOpacity>
 
           <TouchableOpacity
             style={[styles.applePayBtn, !timeSlot && styles.applePayBtnDisabled]}
             disabled={!timeSlot}
-            onPress={() => {
+            onPress={async () => {
               if (!timeSlot) return;
-              // hook up your Apple Pay flow here
+              const receipt = buildReceipt({
+                cartItems: items,
+                selectedTimeSlot: timeSlot,
+                customer: null,
+                pifContribution: 0,
+                vouchersApplied: 0,
+                paymentMethod: 'test',
+              });
+              await sendReceiptToPOS(receipt);
+              try {
+                const { data: session } = await supabase.auth.getSession();
+                const userId = session?.session?.user?.id;
+                if (userId) {
+                  await saveReceiptForUser(userId, receipt);
+                  const add = countStampsFromReceipt(receipt);
+                  if (add > 0) {
+                    const { error } = await supabase.rpc('award_stamps', {
+                      p_user: userId,
+                      p_order_id: receipt.orderId,
+                      p_add: add,
+                    });
+                    if (error) console.warn('[LOYALTY] award_stamps failed', error);
+                  }
+                  try { await refreshStats(); } catch {}
+                }
+              } catch {}
+              Alert.alert('Order placed', `Pickup code: ${receipt.pickupCode}`);
+              clear?.();
+              setTimeSlot(null);
             }}
           >
             <Text style={styles.applePayText}> Pay</Text>

--- a/src/screens/OrderDetailScreen.tsx
+++ b/src/screens/OrderDetailScreen.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { ScrollView, View, Text } from 'react-native';
+import { palette } from '../design/theme';
+
+export default function OrderDetailScreen({ route }) {
+  const { order } = route.params;
+  const r = order?.receipt || {};
+  return (
+    <ScrollView contentContainerStyle={{ padding:16 }}>
+      <Text style={{ fontSize:18, fontWeight:'700' }}>{r?.items?.[0]?.name || 'Order'} — £{(order.totals_cents/100).toFixed(2)}</Text>
+      <Text style={{ marginTop:4 }}>Code: {order.pickup_code}</Text>
+      <Text style={{ marginTop:4 }}>{new Date(order.created_at).toLocaleString()}</Text>
+      <View style={{ height:12 }} />
+      {r?.items?.map((it, idx) => (
+        <View key={idx} style={{ borderWidth:1, borderColor: palette.border, borderRadius:12, padding:12, marginBottom:10 }}>
+          <Text style={{ fontWeight:'700' }}>{it.quantity} × {it.name} — £{it.unitFinalPrice.toFixed(2)}</Text>
+          {it?.modifiers?.length ? it.modifiers.map((m, i) => (
+            <Text key={i} style={{ color: palette.coffee }}>
+              • {m.type === 'extraShot' ? `+${m.count} shot${m.count>1?'s':''}` : m.label}
+              {m.priceDelta ? ` (+£${m.priceDelta.toFixed(2)})` : ''}
+            </Text>
+          )) : null}
+        </View>
+      ))}
+      <View style={{ height:8 }} />
+      <Text>Subtotal: £{r?.totals?.subtotal?.toFixed(2) ?? (order.totals_cents/100).toFixed(2)}</Text>
+      <Text>Tax: £{r?.totals?.tax?.toFixed(2) ?? '0.00'}</Text>
+      <Text style={{ fontWeight:'700' }}>TOTAL: £{(order.totals_cents/100).toFixed(2)}</Text>
+    </ScrollView>
+  );
+}

--- a/src/screens/OrdersScreen.tsx
+++ b/src/screens/OrdersScreen.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { View, Text, FlatList, Pressable, StyleSheet } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { fetchUserOrders, subscribeUserOrders } from '../services/orders';
+import { palette } from '../design/theme';
+
+export default function OrdersScreen({ navigation }) {
+  const [orders, setOrders] = useState<any[]>([]);
+
+  const load = useCallback(async () => {
+    try { setOrders(await fetchUserOrders()); } catch {}
+  }, []);
+
+  useFocusEffect(useCallback(() => {
+    let off = subscribeUserOrders(load);
+    load();
+    return () => { off?.(); };
+  }, [load]));
+
+  const renderItem = ({ item }) => {
+    const total = (item.totals_cents ?? 0) / 100;
+    const when = new Date(item.created_at);
+    const subtitle = (item.items?.[0]?.name || 'Order') +
+      (item.items?.length > 1 ? ` + ${item.items.length - 1} more` : '');
+    return (
+      <Pressable style={styles.card} onPress={() => navigation.navigate('OrderDetail', { order: item })}>
+        <View style={styles.rowBetween}>
+          <Text style={styles.title}>{subtitle}</Text>
+          <Text style={styles.total}>{`£${total.toFixed(2)}`}</Text>
+        </View>
+        <View style={styles.rowBetween}>
+          <Text style={styles.muted}>{when.toLocaleString()}</Text>
+          <View style={[styles.badge, badgeStyle(item.status)]}>
+            <Text style={styles.badgeText}>{item.status}</Text>
+          </View>
+        </View>
+        <Text style={styles.code}>Code: {item.pickup_code}</Text>
+      </Pressable>
+    );
+  };
+
+  return (
+    <FlatList
+      contentContainerStyle={styles.content}
+      data={orders}
+      keyExtractor={(o) => o.id}
+      renderItem={renderItem}
+      ListEmptyComponent={<Text style={styles.empty}>No orders yet.</Text>}
+    />
+  );
+}
+
+const badgeStyle = (status: string) => ({
+  backgroundColor:
+    status === 'ready' ? '#C8E6C9' :
+    status === 'in_progress' ? '#FFE0B2' :
+    status === 'picked_up' ? '#CFD8DC' : '#F5F5F5'
+});
+
+const styles = StyleSheet.create({
+  content: { padding: 16, paddingBottom: 24 },
+  card: { backgroundColor: palette.paper, borderColor: palette.border, borderWidth: 1, borderRadius: 14, padding: 16, marginBottom: 14 },
+  rowBetween: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  title: { fontSize: 16, color: palette.coffee, fontFamily: 'Fraunces_700Bold' },
+  total: { fontSize: 16, fontFamily: 'Fraunces_700Bold', color: palette.clay },
+  muted: { color: palette.coffee },
+  badge: { paddingHorizontal: 10, paddingVertical: 4, borderRadius: 999 },
+  badgeText: { fontWeight: '600', color: '#333' },
+  code: { marginTop: 8, fontWeight: '700', color: palette.coffee },
+  empty: { textAlign: 'center', marginTop: 40, color: palette.coffee }
+});

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -1,0 +1,62 @@
+import { supabase } from '../lib/supabase';
+import type { Receipt } from '../utils/receipt';
+
+type VoidFn = () => void;
+const listeners = new Set<VoidFn>();
+
+export function onLocalOrdersChange(fn: VoidFn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+function emitLocalOrdersChange() {
+  listeners.forEach((fn) => {
+    try {
+      fn();
+    } catch {}
+  });
+}
+
+export async function saveReceiptForUser(userId: string, receipt: Receipt) {
+  const grandTotalCents = Math.round((receipt?.totals?.grandTotal || 0) * 100);
+  const { error } = await supabase.from('orders').insert([{
+    user_id: userId,
+    order_id: receipt.orderId,
+    pickup_code: receipt.pickupCode,
+    status: 'pending',
+    totals_cents: grandTotalCents,
+    currency: receipt?.totals?.currency || 'GBP',
+    channel: receipt.channel,
+    payment_method: receipt.paymentMethod,
+    time_slot: receipt.timeSlot,
+    items: receipt.items,
+    receipt,
+  }]);
+  if (error) throw error;
+  emitLocalOrdersChange();
+}
+
+export async function fetchUserOrders() {
+  const { data: session } = await supabase.auth.getSession();
+  const uid = session?.session?.user?.id;
+  if (!uid) return [];
+  const { data, error } = await supabase
+    .from('orders')
+    .select('*')
+    .eq('user_id', uid)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return data || [];
+}
+
+export function subscribeUserOrders(onChange: () => void) {
+  const channel = supabase
+    .channel('orders-realtime')
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'orders' }, () => onChange())
+    .subscribe();
+  return () => {
+    try {
+      channel.unsubscribe();
+    } catch {}
+  };
+}

--- a/src/utils/loyalty.ts
+++ b/src/utils/loyalty.ts
@@ -1,0 +1,10 @@
+import type { Receipt } from './receipt.js';
+
+// Counts qualifying stamps from a Receipt (exclude modifiers)
+export function countStampsFromReceipt(receipt: Receipt): number {
+  if (!receipt?.items?.length) return 0;
+  return receipt.items.reduce(
+    (sum, it) => sum + Math.max(0, Number(it.quantity || 0)),
+    0
+  );
+}

--- a/src/utils/receipt.ts
+++ b/src/utils/receipt.ts
@@ -1,0 +1,219 @@
+
+export type ReceiptItemModifier =
+  | { type: 'altMilk'; label: string; priceDelta: number }
+  | { type: 'syrup'; label: string; priceDelta: number }
+  | { type: 'coffeeBlend'; label: string; priceDelta: number }
+  | { type: 'extraShot'; count: number; priceDelta: number };
+
+export type ReceiptItem = {
+  id: string;
+  name: string;
+  quantity: number;
+  unitBasePrice: number;
+  unitModifierTotal: number;
+  unitFinalPrice: number;
+  lineTotal: number;
+  modifiers: ReceiptItemModifier[];
+  notes?: string;
+};
+
+export type ReceiptTotals = {
+  currency: 'GBP';
+  subtotal: number;
+  discounts: number;
+  pifContribution: number;
+  tax: number;
+  grandTotal: number;
+};
+
+export type Receipt = {
+  orderId: string;
+  pickupCode: string;
+  createdAt: string;
+  channel: 'click_and_collect';
+  paymentMethod: 'apple_pay' | 'card' | 'cash' | 'test';
+  customer?: { id?: string; email?: string };
+  timeSlot: { startISO: string; endISO: string };
+  items: ReceiptItem[];
+  totals: ReceiptTotals;
+  vouchersRedeemed?: number;
+  freeDrinksUsed?: number;
+  meta?: Record<string, any>;
+};
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function formatISO(d: Date): string {
+  return d.toISOString();
+}
+
+export function buildReceipt({
+  cartItems,
+  selectedTimeSlot,
+  customer,
+  pifContribution = 0,
+  vouchersApplied = 0,
+  paymentMethod = 'test',
+  rng = Math.random,
+  uuidGenerator = () => (globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : Math.random().toString(36).slice(2)),
+}: {
+  cartItems: Array<{
+    id: string;
+    name: string;
+    quantity: number;
+    price: number;
+    modifiers?: {
+      altMilk?: string;
+      syrups?: string[];
+      coffeeBlend?: string;
+      extraShots?: number;
+    };
+    notes?: string;
+  }>;
+  selectedTimeSlot: { start: Date; end: Date };
+  customer?: { id?: string; email?: string } | null;
+  pifContribution?: number;
+  vouchersApplied?: number;
+  paymentMethod?: 'apple_pay' | 'card' | 'cash' | 'test';
+  rng?: () => number;
+  uuidGenerator?: () => string;
+}): Receipt {
+  const items: ReceiptItem[] = cartItems.map((item) => {
+    const mods: ReceiptItemModifier[] = [];
+    let unitModifierTotal = 0;
+    const m = item.modifiers || {};
+    if (m.altMilk) {
+      mods.push({ type: 'altMilk', label: m.altMilk, priceDelta: 0 });
+    }
+    if (m.syrups) {
+      m.syrups.forEach((s) => {
+        mods.push({ type: 'syrup', label: s, priceDelta: 0.5 });
+      });
+      unitModifierTotal += 0.5 * m.syrups.length;
+    }
+    if (m.coffeeBlend) {
+      mods.push({ type: 'coffeeBlend', label: m.coffeeBlend, priceDelta: 0 });
+    }
+    if (typeof m.extraShots === 'number' && m.extraShots > 0) {
+      mods.push({ type: 'extraShot', count: m.extraShots, priceDelta: 1.49 });
+      unitModifierTotal += 1.49 * m.extraShots;
+    }
+    unitModifierTotal = round2(unitModifierTotal);
+    const unitBasePrice = round2(item.price);
+    const unitFinalPrice = round2(unitBasePrice + unitModifierTotal);
+    const lineTotal = round2(unitFinalPrice * item.quantity);
+    return {
+      id: item.id,
+      name: item.name,
+      quantity: item.quantity,
+      unitBasePrice,
+      unitModifierTotal,
+      unitFinalPrice,
+      lineTotal,
+      modifiers: mods,
+      notes: item.notes,
+    };
+  });
+
+  const subtotal = round2(items.reduce((sum, i) => sum + i.lineTotal, 0));
+  let discounts = 0;
+  let vouchersLeft = vouchersApplied;
+  for (const item of items) {
+    if (vouchersLeft <= 0) break;
+    const redeem = Math.min(vouchersLeft, item.quantity);
+    discounts += redeem * item.unitBasePrice;
+    vouchersLeft -= redeem;
+  }
+  discounts = round2(discounts);
+  const tax = 0;
+  const pif = round2(pifContribution);
+  const grandTotal = round2(subtotal - discounts + pif + tax);
+
+  const orderId = uuidGenerator();
+  const pickupCode = String(Math.floor(rng() * 100000)).padStart(5, '0');
+  const createdAt = formatISO(new Date());
+
+  return {
+    orderId,
+    pickupCode,
+    createdAt,
+    channel: 'click_and_collect',
+    paymentMethod,
+    customer: customer || undefined,
+    timeSlot: {
+      startISO: formatISO(selectedTimeSlot.start),
+      endISO: formatISO(selectedTimeSlot.end),
+    },
+    items,
+    totals: {
+      currency: 'GBP',
+      subtotal,
+      discounts,
+      pifContribution: pif,
+      tax,
+      grandTotal,
+    },
+    vouchersRedeemed: vouchersApplied || undefined,
+  };
+}
+
+function formatTimeRange(startISO: string, endISO: string): string {
+  const start = new Date(startISO);
+  const end = new Date(endISO);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${start.getFullYear()}-${pad(start.getMonth() + 1)}-${pad(start.getDate())} ` +
+    `${pad(start.getHours())}:${pad(start.getMinutes())}–${pad(end.getHours())}:${pad(end.getMinutes())}`;
+}
+
+export function printReceiptToConsole(receipt: Receipt): void {
+  const lines: string[] = [];
+  lines.push('=== RECEIPT (TEST LOG) ===');
+  lines.push('Ruminate — Click & Collect');
+  lines.push(`Order: ${receipt.orderId}   Code: ${receipt.pickupCode}`);
+  lines.push(`When: ${formatTimeRange(receipt.timeSlot.startISO, receipt.timeSlot.endISO)}`);
+  lines.push('');
+  receipt.items.forEach((item) => {
+    lines.push(`${item.quantity} × ${item.name}  £${item.unitFinalPrice.toFixed(2)}`);
+    item.modifiers.forEach((m) => {
+      if (m.type === 'altMilk') lines.push(`   • ${m.label}`);
+      if (m.type === 'syrup') lines.push(`   • ${m.label} (+£${m.priceDelta.toFixed(2)})`);
+      if (m.type === 'coffeeBlend') lines.push(`   • ${m.label}`);
+      if (m.type === 'extraShot') lines.push(`   • +${m.count} shot${m.count > 1 ? 's' : ''} (+£${(m.priceDelta * m.count).toFixed(2)})`);
+    });
+    lines.push(`   = £${item.lineTotal.toFixed(2)}`);
+    lines.push('');
+  });
+  lines.push(`Subtotal: £${receipt.totals.subtotal.toFixed(2)}`);
+  if (receipt.vouchersRedeemed) {
+    lines.push(`Vouchers used: ${receipt.vouchersRedeemed} (−£${receipt.totals.discounts.toFixed(2)})`);
+  }
+  if (receipt.totals.pifContribution) {
+    lines.push(`PIF: £${receipt.totals.pifContribution.toFixed(2)}`);
+  }
+  lines.push(`Tax: £${receipt.totals.tax.toFixed(2)}`);
+  lines.push(`TOTAL: £${receipt.totals.grandTotal.toFixed(2)}`);
+  console.log(lines.join('\n'));
+  console.log('=== RECEIPT JSON ===');
+  console.log(JSON.stringify(receipt, null, 2));
+}
+
+export async function sendReceiptToPOS(receipt: Receipt): Promise<void> {
+  const endpoint = process.env.EXPO_PUBLIC_POS_ENDPOINT;
+  if (!endpoint) {
+    printReceiptToConsole(receipt);
+    return;
+  }
+  try {
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(receipt),
+    });
+  } catch (err) {
+    console.error('Failed to send receipt to POS', err);
+    printReceiptToConsole(receipt);
+  }
+}
+


### PR DESCRIPTION
## Summary
- buildReceipt converts cart + time slot into structured receipt with modifiers, totals and random identifiers
- add console printer and POS shim; wire CartScreen pay flow to generate and send receipt then clear cart
- persist receipts to Supabase and display past orders with detail view and conditional Orders tab
- award loyalty stamps per receipt line item and refresh counters across the app
- ensure Orders tab becomes visible after a purchase and on app launch when history exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3248918c8322862fc096cad68d03