### PR TITLE
fix loyalty stats fetch and order source

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import { useFonts, Fraunces_600SemiBold, Fraunces_700Bold } from '@expo-google-f
 import appBgBase64 from './assets/appBgBase64';
 import SplashGate from './src/components/SplashGate';
 import { supabase } from './src/lib/supabase';
+import { getMyStats } from './src/services/stats';
 
 export default function App() {
   const [loaded] = useFonts({ Fraunces_600SemiBold, Fraunces_700Bold });
@@ -18,13 +19,9 @@ export default function App() {
       const uid = data?.session?.user?.id;
       if (uid) {
         try {
-          const { data: row } = await supabase
-            .from('profiles')
-            .select('loyalty_stamps, free_drinks')
-            .eq('id', uid)
-            .single();
+          const { loyaltyStamps, freebiesLeft } = await getMyStats();
           console.log(
-            `[LOYALTY] on boot → stamps: ${row?.loyalty_stamps ?? 0}, free drinks: ${row?.free_drinks ?? 0}`
+            `[LOYALTY] on boot → stamps: ${loyaltyStamps}, free drinks: ${freebiesLeft}`
           );
         } catch {}
       }

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -12,6 +12,7 @@ export async function saveReceiptForUser(userId: string, receipt: Receipt) {
     totals_cents: totalsCents,
     currency: receipt?.totals?.currency || 'GBP',
     channel: receipt.channel,
+    source: 'app',
     payment_method: receipt.paymentMethod,
     time_slot: receipt.timeSlot,
     items: receipt.items,

--- a/supabase/migrations/0006_award_stamps.sql
+++ b/supabase/migrations/0006_award_stamps.sql
@@ -1,0 +1,41 @@
+CREATE OR REPLACE FUNCTION public.award_stamps(
+  p_user uuid,
+  p_order_id uuid,
+  p_add integer
+)
+RETURNS TABLE(updated_stamps integer, updated_free_drinks integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  total integer;
+  to_mint integer;
+  remainder integer;
+BEGIN
+  -- record new stamps entry
+  INSERT INTO loyalty_stamps(user_id, stamps)
+  VALUES (p_user, p_add);
+
+  SELECT COALESCE(SUM(stamps),0) INTO total
+  FROM loyalty_stamps WHERE user_id = p_user;
+
+  to_mint := total / 8;
+  remainder := MOD(total, 8);
+
+  IF total <> remainder THEN
+    DELETE FROM loyalty_stamps WHERE user_id = p_user;
+    IF remainder > 0 THEN
+      INSERT INTO loyalty_stamps(user_id, stamps) VALUES (p_user, remainder);
+    END IF;
+  END IF;
+
+  IF to_mint > 0 THEN
+    INSERT INTO drink_vouchers(user_id, code)
+    SELECT p_user, gen_random_uuid() FROM generate_series(1, to_mint);
+  END IF;
+
+  RETURN QUERY
+  SELECT remainder,
+    (SELECT COUNT(*) FROM drink_vouchers WHERE user_id = p_user AND redeemed = false);
+END;
+$$;


### PR DESCRIPTION
## Summary
- include source field when saving orders so inserts satisfy schema
- load loyalty stats on boot using getMyStats
- add SQL function `award_stamps` to grant stamps and mint vouchers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0499d518c8322af757d9d309d910b