### PR TITLE
fix loyalty stats fetch and order source

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import { useFonts, Fraunces_600SemiBold, Fraunces_700Bold } from '@expo-google-f
 import appBgBase64 from './assets/appBgBase64';
 import SplashGate from './src/components/SplashGate';
 import { supabase } from './src/lib/supabase';
+import { getMyStats } from './src/services/stats';
 
 export default function App() {
   const [loaded] = useFonts({ Fraunces_600SemiBold, Fraunces_700Bold });
@@ -18,13 +19,9 @@ export default function App() {
       const uid = data?.session?.user?.id;
       if (uid) {
         try {
-          const { data: row } = await supabase
-            .from('profiles')
-            .select('loyalty_stamps, free_drinks')
-            .eq('id', uid)
-            .single();
+          const { loyaltyStamps, freebiesLeft } = await getMyStats();
           console.log(
-            `[LOYALTY] on boot → stamps: ${row?.loyalty_stamps ?? 0}, free drinks: ${row?.free_drinks ?? 0}`
+            `[LOYALTY] on boot → stamps: ${loyaltyStamps}, free drinks: ${freebiesLeft}`
           );
         } catch {}
       }

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -12,6 +12,7 @@ export async function saveReceiptForUser(userId: string, receipt: Receipt) {
     totals_cents: totalsCents,
     currency: receipt?.totals?.currency || 'GBP',
     channel: receipt.channel,
+    source: 'app',
     payment_method: receipt.paymentMethod,
     time_slot: receipt.timeSlot,
     items: receipt.items,

--- a/supabase/migrations/0006_award_stamps.sql
+++ b/supabase/migrations/0006_award_stamps.sql
@@ -1,0 +1,263 @@
+-- Idempotent migration to ensure orders table shape, profiles loyalty fields,
+-- policies, loyalty_awards ledger and award_stamps RPC.
+
+-- 1. Orders table shape & constraints
+create table if not exists public.orders (
+    user_id uuid,
+    order_id text,
+    pickup_code text,
+    status text default 'pending',
+    totals_cents int default 0,
+    currency text default 'GBP',
+    channel text default 'click_and_collect',
+    source text default 'app',
+    payment_method text,
+    time_slot jsonb,
+    time_slot_start timestamptz,
+    time_slot_end timestamptz,
+    items jsonb,
+    receipt jsonb,
+    created_at timestamptz default now()
+);
+
+alter table public.orders
+  add column if not exists user_id uuid,
+  add column if not exists order_id text,
+  add column if not exists pickup_code text,
+  add column if not exists status text default 'pending',
+  add column if not exists totals_cents int default 0,
+  add column if not exists currency text default 'GBP',
+  add column if not exists channel text default 'click_and_collect',
+  add column if not exists source text default 'app',
+  add column if not exists payment_method text,
+  add column if not exists time_slot jsonb,
+  add column if not exists time_slot_start timestamptz,
+  add column if not exists time_slot_end timestamptz,
+  add column if not exists items jsonb,
+  add column if not exists receipt jsonb,
+  add column if not exists created_at timestamptz default now();
+
+alter table public.orders
+  alter column user_id set not null,
+  alter column order_id set not null,
+  alter column status set not null,
+  alter column totals_cents set not null,
+  alter column currency set not null,
+  alter column channel set not null,
+  alter column source set not null,
+  alter column created_at set not null;
+
+alter table public.orders
+  alter column status set default 'pending',
+  alter column totals_cents set default 0,
+  alter column currency set default 'GBP',
+  alter column channel set default 'click_and_collect',
+  alter column source set default 'app',
+  alter column created_at set default now();
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'orders_user_id_fkey') then
+    alter table public.orders
+      add constraint orders_user_id_fkey foreign key (user_id) references auth.users(id) on delete cascade;
+  end if;
+end$$;
+
+create unique index if not exists orders_order_id_key on public.orders(order_id);
+
+alter table public.orders enable row level security;
+
+do $$
+begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='orders' and policyname='orders_select_own') then
+    drop policy orders_select_own on public.orders;
+  end if;
+  create policy orders_select_own on public.orders for select using (auth.uid() = user_id);
+end$$;
+
+do $$
+begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='orders' and policyname='orders_insert_own') then
+    drop policy orders_insert_own on public.orders;
+  end if;
+  create policy orders_insert_own on public.orders for insert with check (auth.uid() = user_id);
+end$$;
+
+do $$
+begin
+  if exists (select 1 from pg_constraint where conname = 'orders_source_check') then
+    alter table public.orders drop constraint orders_source_check;
+  end if;
+  alter table public.orders add constraint orders_source_check check (source in ('app','pos','portal'));
+end$$;
+
+-- 2. Profiles columns
+alter table public.profiles add column if not exists loyalty_stamps int not null default 0;
+alter table public.profiles add column if not exists free_drinks int not null default 0;
+
+-- 3. RLS on profiles (select own)
+alter table public.profiles enable row level security;
+
+do $$
+declare pk text;
+begin
+  select column_name into pk
+  from information_schema.columns
+  where table_schema='public' and table_name='profiles' and column_name in ('id','user_id')
+  order by column_name='id' desc
+  limit 1;
+
+  if pk is null then
+    raise exception 'profiles identifier column not found';
+  end if;
+
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='profiles' and policyname='profiles_select_own') then
+    execute 'drop policy profiles_select_own on public.profiles';
+  end if;
+  execute format('create policy profiles_select_own on public.profiles for select using (auth.uid() = %I)', pk);
+end$$;
+
+-- 4. Loyalty idempotency ledger
+do $$
+declare pk text;
+begin
+  select column_name into pk
+  from information_schema.columns
+  where table_schema='public' and table_name='profiles' and column_name in ('id','user_id')
+  order by column_name='id' desc
+  limit 1;
+
+  if pk is null then
+    raise exception 'profiles identifier column not found';
+  end if;
+
+  if not exists (select 1 from pg_tables where schemaname='public' and tablename='loyalty_awards') then
+    execute format('create table public.loyalty_awards (order_id text primary key, user_id uuid not null references public.profiles(%I) on delete cascade, stamps int not null check (stamps >= 0), created_at timestamptz not null default now())', pk);
+  end if;
+end$$;
+
+alter table public.loyalty_awards enable row level security;
+
+do $$
+begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='loyalty_awards' and policyname='loyalty_awards_read_own') then
+    drop policy loyalty_awards_read_own on public.loyalty_awards;
+  end if;
+  create policy loyalty_awards_read_own on public.loyalty_awards for select using (auth.uid() = user_id);
+end$$;
+
+do $$
+begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='loyalty_awards' and policyname='loyalty_awards_insert_own') then
+    drop policy loyalty_awards_insert_own on public.loyalty_awards;
+  end if;
+  create policy loyalty_awards_insert_own on public.loyalty_awards for insert with check (auth.uid() = user_id);
+end$$;
+
+-- 5. RPC award_stamps
+drop function if exists public.award_stamps(uuid, text, int);
+
+create function public.award_stamps(p_user uuid, p_order_id text, p_add int)
+returns table(loyalty_stamps int, free_drinks int)
+language plpgsql
+security definer
+as $$
+declare
+  pk text;
+  inserted int;
+  cur_stamps int;
+  cur_free int;
+begin
+  select column_name into pk
+  from information_schema.columns
+  where table_schema='public' and table_name='profiles' and column_name in ('id','user_id')
+  order by column_name='id' desc
+  limit 1;
+
+  if pk is null then
+    raise exception 'profiles identifier column not found';
+  end if;
+
+  if p_add <= 0 then
+    execute format('select loyalty_stamps, free_drinks from public.profiles where %I=$1', pk)
+      into loyalty_stamps, free_drinks
+      using p_user;
+    return;
+  end if;
+
+  insert into public.loyalty_awards(order_id, user_id, stamps)
+  values (p_order_id, p_user, p_add)
+  on conflict (order_id) do nothing;
+  get diagnostics inserted = row_count;
+  if inserted = 0 then
+    execute format('select loyalty_stamps, free_drinks from public.profiles where %I=$1', pk)
+      into loyalty_stamps, free_drinks
+      using p_user;
+    return;
+  end if;
+
+  execute format('select loyalty_stamps, free_drinks from public.profiles where %I=$1 for update', pk)
+    into cur_stamps, cur_free
+    using p_user;
+
+  cur_stamps := coalesce(cur_stamps,0) + p_add;
+  cur_free := coalesce(cur_free,0);
+
+  free_drinks := cur_free + (cur_stamps / 8);
+  loyalty_stamps := mod(cur_stamps, 8);
+
+  execute format('update public.profiles set loyalty_stamps=$1, free_drinks=$2 where %I=$3', pk)
+    using loyalty_stamps, free_drinks, p_user;
+
+  return;
+end;
+$$;
+
+grant execute on function public.award_stamps(uuid, text, int) to authenticated;
+
+-- 6. Schema cache refresh
+notify pgrst, 'reload schema';
+
+-- Acceptance tests
+-- insert orders row
+DO $$
+DECLARE u uuid;
+BEGIN
+  SELECT id INTO u FROM auth.users LIMIT 1;
+  INSERT INTO public.orders(user_id, order_id, source, channel)
+    VALUES (u, 'test-oid', 'app', 'click_and_collect');
+  DELETE FROM public.orders WHERE order_id='test-oid';
+END$$;
+
+-- award_stamps with zero addition
+SELECT * FROM public.award_stamps(gen_random_uuid(), 'order-xyz', 0);
+
+-- roll stamps into free drink
+DO $$
+DECLARE u uuid := gen_random_uuid();
+       ls int;
+       fd int;
+       cnt int;
+       pk text;
+BEGIN
+  SELECT column_name INTO pk
+  FROM information_schema.columns
+  WHERE table_schema='public' AND table_name='profiles' AND column_name IN ('id','user_id')
+  ORDER BY column_name='id' DESC
+  LIMIT 1;
+
+  EXECUTE format('INSERT INTO public.profiles(%I, loyalty_stamps, free_drinks) VALUES ($1,5,1)', pk) USING u;
+
+  SELECT loyalty_stamps, free_drinks INTO ls, fd FROM public.award_stamps(u, 'o1', 3);
+  IF ls <> 0 OR fd <> 2 THEN
+    RAISE EXCEPTION 'unexpected totals % %', ls, fd;
+  END IF;
+
+  SELECT count(*) INTO cnt FROM public.loyalty_awards WHERE order_id='o1';
+  IF cnt <> 1 THEN
+    RAISE EXCEPTION 'loyalty_awards count %', cnt;
+  END IF;
+
+  DELETE FROM public.loyalty_awards WHERE order_id='o1';
+  EXECUTE format('DELETE FROM public.profiles WHERE %I=$1', pk) USING u;
+END$$;


### PR DESCRIPTION
## Summary
- include source field when saving orders so inserts satisfy schema
- load loyalty stats on boot using getMyStats
- add idempotent migration: orders table columns/constraints, profiles loyalty fields/policies, loyalty_awards ledger, and award_stamps RPC

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0499d518c8322af757d9d309d910b