### PR TITLE
feat: redeem vouchers at checkout and sync loyalty

### DIFF
--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -9,14 +9,16 @@ import { buildReceipt, sendReceiptToPOS, printReceiptToConsole } from '../utils/
 import { saveReceiptForUser } from '../services/orders';
 import { useOrdersPresence } from '../context/OrdersContext';
 import { supabase } from '../lib/supabase';
-import { countStampsFromReceipt } from '../utils/loyalty';
 import { useStats } from '../hooks/useStats';
 import { getMembershipSummary } from '../services/membership';
 import { getToday } from '../services/homeData';
+import { checkoutLoyalty } from '../services/loyalty';
 
 export default function CartScreen({ navigation }) {
   const insets = useSafeAreaInsets();
-  const { refreshStats } = useStats?.() || { refreshStats: async () => {} };
+  const { stats = { freebiesLeft: 0 }, refreshStats } =
+    useStats?.() || { stats: { freebiesLeft: 0 }, refreshStats: async () => {} };
+  const freeDrinks = stats?.freebiesLeft ?? 0;
   const { setHasOrders, refreshOrdersPresence } = useOrdersPresence();
 
   const tabBarHeight = useTabBarHeight();
@@ -33,6 +35,27 @@ export default function CartScreen({ navigation }) {
     clearItem, // some apps name it like this
     clear,
   } = cart;
+  const isDrinkItem = (item) => {
+    const key = (item?.cms_key || item?.id || '').toLowerCase();
+    if (key.includes('.drink')) return true;
+    const category = (item?.category || '').toLowerCase();
+    if (category === 'coffee') return true;
+    if (key.startsWith('coffee:')) return true;
+    return false;
+  };
+
+  const drinkCount = useMemo(
+    () => items.filter(isDrinkItem).reduce((sum, it) => sum + (it.quantity || 0), 0),
+    [items]
+  );
+  const maxRedeemable = Math.min(drinkCount, freeDrinks);
+  const [redeemCount, setRedeemCount] = useState(0);
+  useEffect(() => {
+    setRedeemCount((c) => {
+      if (!Number.isFinite(c) || c < 0) return 0;
+      return Math.min(c, maxRedeemable);
+    });
+  }, [maxRedeemable]);
 
   const [timeSlot, setTimeSlot] = useState(null);
   const [slotPickerVisible, setSlotPickerVisible] = useState(false);
@@ -42,8 +65,9 @@ export default function CartScreen({ navigation }) {
   useEffect(() => {
     (async () => {
       try { const t = await getToday(); setTodayHours(t); } catch {}
+      try { await refreshStats(); } catch {}
     })();
-  }, []);
+  }, [refreshStats]);
 
   const contentBottomPad = useMemo(
 
@@ -199,6 +223,31 @@ export default function CartScreen({ navigation }) {
           <Text style={styles.subtotalValue}>£{subtotal.toFixed(2)}</Text>
         </View>
 
+        <View style={styles.voucherPanel}>
+          <Text style={styles.voucherText}>Free drinks available: {freeDrinks}</Text>
+          <View style={styles.voucherRow}>
+            <Text style={styles.voucherText}>Redeem now:</Text>
+            <View style={styles.voucherCtrls}>
+              <TouchableOpacity
+                style={[styles.voucherBtn, redeemCount === 0 && styles.voucherBtnDisabled]}
+                disabled={redeemCount === 0}
+                onPress={() => setRedeemCount(Math.max(0, redeemCount - 1))}
+              >
+                <Text style={styles.voucherBtnText}>-</Text>
+              </TouchableOpacity>
+              <Text style={styles.voucherCount}>{redeemCount}</Text>
+              <TouchableOpacity
+                style={[styles.voucherBtn, redeemCount >= maxRedeemable && styles.voucherBtnDisabled]}
+                disabled={redeemCount >= maxRedeemable}
+                onPress={() => setRedeemCount(Math.min(maxRedeemable, redeemCount + 1))}
+              >
+                <Text style={styles.voucherBtnText}>+</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+          <Text style={styles.voucherText}>Eligible drink items in cart: {drinkCount}</Text>
+        </View>
+
         <View style={styles.footerButtonsRow}>
           <TouchableOpacity style={styles.slotBtn} onPress={onPickTimeSlot}>
             <Text style={styles.slotBtnText}>{timeSlot ? formatSlotLabel(timeSlot) : 'ASAP'}</Text>
@@ -217,11 +266,12 @@ export default function CartScreen({ navigation }) {
                 selectedTimeSlot: slot,
                 customer: null,
                 pifContribution: 0,
-                vouchersApplied: 0,
+                vouchersApplied: redeemCount,
                 paymentMethod: 'test',
               });
 
               const canonical = JSON.parse(JSON.stringify(receipt));
+              canonical.freeDrinksUsed = redeemCount;
               printReceiptToConsole(canonical);
               await sendReceiptToPOS(canonical);
               let inserted;
@@ -229,7 +279,7 @@ export default function CartScreen({ navigation }) {
               const userId = session?.session?.user?.id;
               if (userId) {
                 try {
-                  inserted = await saveReceiptForUser(userId, canonical);
+                  inserted = await saveReceiptForUser(userId, canonical, redeemCount);
                   console.log('[ORDERS] saved →', inserted?.id, inserted?.order_id);
                   setHasOrders(true);
                   try { await refreshOrdersPresence(); } catch {}
@@ -239,28 +289,27 @@ export default function CartScreen({ navigation }) {
                 }
               }
 
-              const add = countStampsFromReceipt(canonical);
+              const stampsToAward = Math.max(0, drinkCount - redeemCount);
               console.log(
-                `[LOYALTY] considering award for order ${canonical.orderId}: +${add} stamp(s)`
+                `[CHECKOUT] drinkCount=${drinkCount}, redeemCount=${redeemCount}, stampsToAward=${stampsToAward}`
               );
-              if (userId && add > 0) {
-                const { data, error } = await supabase.rpc('award_stamps', {
-                  p_user: userId,
-                  p_order_id: canonical.orderId,
-                  p_add: add,
-                });
+              if (userId) {
+                const { data, error } = await checkoutLoyalty(
+                  userId,
+                  canonical.orderId,
+                  stampsToAward,
+                  redeemCount
+                );
                 if (error) {
-                  console.warn('[LOYALTY] award_stamps failed:', error);
+                  console.warn('[LOYALTY] checkout_loyalty failed:', error);
                 } else {
                   const [row] = Array.isArray(data) ? data : [];
-                  const stampsNow = row?.updated_stamps ?? null;
-                  const freeNow = row?.updated_free_drinks ?? null;
                   console.log(
-                    `[LOYALTY] awarded +${add}. Now → stamps: ${stampsNow}, free drinks: ${freeNow}`
+                    `[LOYALTY] awarded ${stampsToAward}, redeemed ${redeemCount} → totals: stamps=${row?.loyalty_stamps}, free_drinks=${row?.free_drinks}`
                   );
                 }
               } else {
-                console.log('[LOYALTY] no stamps awarded (no user or zero qualifying items).');
+                console.log('[LOYALTY] no stamps awarded (no user).');
               }
 
 
@@ -278,6 +327,7 @@ export default function CartScreen({ navigation }) {
 
               clear?.();
               setTimeSlot(null);
+              setRedeemCount(0);
             }}
           >
             <Text style={styles.applePayText}> Pay</Text>
@@ -490,6 +540,48 @@ const styles = StyleSheet.create({
   footerButtonsRow: {
     flexDirection: 'row',
     gap: 10,
+  },
+
+  voucherPanel: {
+    marginBottom: 10,
+  },
+  voucherText: {
+    color: palette.coffee,
+    fontFamily: 'Fraunces_600SemiBold',
+    marginBottom: 4,
+  },
+  voucherRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  voucherCtrls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginLeft: 8,
+  },
+  voucherBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    backgroundColor: palette.cream,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  voucherBtnDisabled: {
+    opacity: 0.3,
+  },
+  voucherBtnText: {
+    fontSize: 18,
+    color: palette.coffee,
+    fontFamily: 'Fraunces_700Bold',
+  },
+  voucherCount: {
+    marginHorizontal: 8,
+    minWidth: 20,
+    textAlign: 'center',
+    fontFamily: 'Fraunces_700Bold',
+    color: palette.coffee,
   },
 
   slotBtn: {

--- a/src/screens/OrderDetailScreen.tsx
+++ b/src/screens/OrderDetailScreen.tsx
@@ -24,6 +24,9 @@ export default function OrderDetailScreen({ route }) {
       ))}
       <View style={{ height:8 }} />
       <Text>Subtotal: £{r?.totals?.subtotal?.toFixed(2) ?? (order.totals_cents/100).toFixed(2)}</Text>
+      { (order?.free_drinks_redeemed || r?.freeDrinksUsed) ? (
+        <Text>Free drinks redeemed: {order?.free_drinks_redeemed || r?.freeDrinksUsed}</Text>
+      ) : null }
       <Text>Tax: £{r?.totals?.tax?.toFixed(2) ?? '0.00'}</Text>
       <Text style={{ fontWeight:'700' }}>TOTAL: £{(order.totals_cents/100).toFixed(2)}</Text>
     </ScrollView>

--- a/src/screens/OrdersScreen.tsx
+++ b/src/screens/OrdersScreen.tsx
@@ -38,6 +38,9 @@ export default function OrdersScreen({ navigation }) {
           </View>
         </View>
         <Text style={styles.code}>Code: {item.pickup_code}</Text>
+        {item?.free_drinks_redeemed > 0 && (
+          <Text style={styles.code}>Free drinks redeemed: {item.free_drinks_redeemed}</Text>
+        )}
       </Pressable>
     );
   };

--- a/src/services/loyalty.js
+++ b/src/services/loyalty.js
@@ -10,3 +10,17 @@ export async function redeemLoyaltyReward() {
     return false;
   }
 }
+
+export async function checkoutLoyalty(p_user, p_order_id, p_add_stamps, p_redeem) {
+  if (!hasSupabase || !supabase) return { data: null, error: new Error('no supabase') };
+  try {
+    return await supabase.rpc('checkout_loyalty', {
+      p_user,
+      p_order_id,
+      p_add_stamps,
+      p_redeem,
+    });
+  } catch (error) {
+    return { data: null, error };
+  }
+}

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -1,7 +1,7 @@
 import { supabase } from '../lib/supabase';
 import type { Receipt } from '../utils/receipt';
 
-export async function saveReceiptForUser(userId: string, receipt: Receipt) {
+export async function saveReceiptForUser(userId: string, receipt: Receipt, freeDrinksRedeemed = 0) {
   const totalsCents = Math.round((receipt?.totals?.grandTotal || 0) * 100);
 
   const payload = {
@@ -17,6 +17,7 @@ export async function saveReceiptForUser(userId: string, receipt: Receipt) {
     time_slot: receipt.timeSlot,
     items: receipt.items,
     receipt,
+    free_drinks_redeemed: freeDrinksRedeemed,
   };
 
   const { data, error } = await supabase

--- a/supabase/migrations/0008_cart_voucher_redemption.sql
+++ b/supabase/migrations/0008_cart_voucher_redemption.sql
@@ -1,0 +1,96 @@
+alter table public.orders
+  add column if not exists free_drinks_redeemed int not null default 0;
+
+create table if not exists public.loyalty_tx (
+  order_id text primary key,
+  user_id uuid not null,
+  stamps_awarded int not null default 0 check (stamps_awarded >= 0),
+  vouchers_redeemed int not null default 0 check (vouchers_redeemed >= 0),
+  created_at timestamptz not null default now(),
+  foreign key (user_id) references public.profiles(id) on delete cascade
+);
+alter table public.loyalty_tx enable row level security;
+
+-- RLS: user can read own rows / insert own
+do $$
+begin
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='loyalty_tx' and policyname='loyalty_tx_read_own') then
+    drop policy loyalty_tx_read_own on public.loyalty_tx;
+  end if;
+  create policy loyalty_tx_read_own on public.loyalty_tx for select using (auth.uid() = user_id);
+
+  if exists (select 1 from pg_policies where schemaname='public' and tablename='loyalty_tx' and policyname='loyalty_tx_insert_own') then
+    drop policy loyalty_tx_insert_own on public.loyalty_tx;
+  end if;
+  create policy loyalty_tx_insert_own on public.loyalty_tx for insert with check (auth.uid() = user_id);
+end$$;
+
+drop function if exists public.checkout_loyalty(uuid, text, int, int);
+
+create function public.checkout_loyalty(
+  p_user uuid,
+  p_order_id text,
+  p_add_stamps int,
+  p_redeem int
+)
+returns table(loyalty_stamps int, free_drinks int)
+language plpgsql
+security definer
+as $$
+declare
+  pk text;
+  cur_stamps int;
+  cur_free int;
+  redeem_used int;
+  inserted int;
+begin
+  -- detect pk (id or user_id)
+  if exists (select 1 from information_schema.columns
+             where table_schema='public' and table_name='profiles' and column_name='user_id') then
+    pk := 'user_id';
+  elsif exists (select 1 from information_schema.columns
+             where table_schema='public' and table_name='profiles' and column_name='id') then
+    pk := 'id';
+  else
+    raise exception 'profiles identifier column not found';
+  end if;
+
+  -- Idempotency: if we already have a tx row for this order_id, return current totals
+  insert into public.loyalty_tx(order_id, user_id, stamps_awarded, vouchers_redeemed)
+    values (p_order_id, p_user, greatest(p_add_stamps,0), greatest(p_redeem,0))
+    on conflict (order_id) do nothing;
+
+  get diagnostics inserted = row_count;
+  execute format('select loyalty_stamps, free_drinks from public.profiles where %I=$1 for update', pk)
+    into cur_stamps, cur_free
+    using p_user;
+
+  if inserted = 0 then
+    -- previously processed: just return current totals
+    loyalty_stamps := coalesce(cur_stamps,0);
+    free_drinks    := coalesce(cur_free,0);
+    return;
+  end if;
+
+  -- Redeem against current free, capping at available
+  redeem_used := least(greatest(p_redeem,0), coalesce(cur_free,0));
+  cur_free := coalesce(cur_free,0) - redeem_used;
+
+  -- Award stamps from non-redeemed drinks
+  cur_stamps := coalesce(cur_stamps,0) + greatest(p_add_stamps,0);
+
+  -- Roll into free drinks
+  free_drinks := cur_free + (cur_stamps / 8);
+  loyalty_stamps := mod(cur_stamps, 8);
+
+  -- Persist
+  execute format('update public.profiles set loyalty_stamps=$1, free_drinks=$2 where %I=$3', pk)
+    using loyalty_stamps, free_drinks, p_user;
+
+  return;
+end;
+$$;
+
+grant execute on function public.checkout_loyalty(uuid, text, int, int) to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add cart voucher selector and clamp to available free drinks
- record free_drinks_redeemed on orders and process loyalty via checkout_loyalty RPC
- show redeemed freebies in order history and detail
- add migration with loyalty_tx ledger and checkout_loyalty RPC

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0588b95408322878f3836bc0e0693