### PR TITLE
Fix orders screen padding and theme receipt view

### DIFF
--- a/src/screens/OrderDetailScreen.tsx
+++ b/src/screens/OrderDetailScreen.tsx
@@ -1,34 +1,48 @@
 import React from 'react';
-import { ScrollView, View, Text } from 'react-native';
+import { ScrollView, View, Text, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { palette } from '../design/theme';
 
 export default function OrderDetailScreen({ route }) {
   const { order } = route.params;
   const r = order?.receipt || {};
   return (
-    <ScrollView contentContainerStyle={{ padding:16 }}>
-      <Text style={{ fontSize:18, fontWeight:'700' }}>{r?.items?.[0]?.name || 'Order'} — £{(order.totals_cents/100).toFixed(2)}</Text>
-      <Text style={{ marginTop:4 }}>Code: {order.pickup_code}</Text>
-      <Text style={{ marginTop:4 }}>{new Date(order.created_at).toLocaleString()}</Text>
-      <View style={{ height:12 }} />
-      {r?.items?.map((it, idx) => (
-        <View key={idx} style={{ borderWidth:1, borderColor: palette.border, borderRadius:12, padding:12, marginBottom:10 }}>
-          <Text style={{ fontWeight:'700' }}>{it.quantity} × {it.name} — £{it.unitFinalPrice.toFixed(2)}</Text>
-          {it?.modifiers?.length ? it.modifiers.map((m, i) => (
-            <Text key={i} style={{ color: palette.coffee }}>
-              • {m.type === 'extraShot' ? `+${m.count} shot${m.count>1?'s':''}` : m.label}
-              {m.priceDelta ? ` (+£${m.priceDelta.toFixed(2)})` : ''}
-            </Text>
-          )) : null}
-        </View>
-      ))}
-      <View style={{ height:8 }} />
-      <Text>Subtotal: £{r?.totals?.subtotal?.toFixed(2) ?? (order.totals_cents/100).toFixed(2)}</Text>
-      { (order?.free_drinks_redeemed || r?.freeDrinksUsed) ? (
-        <Text>Free drinks redeemed: {order?.free_drinks_redeemed || r?.freeDrinksUsed}</Text>
-      ) : null }
-      <Text>Tax: £{r?.totals?.tax?.toFixed(2) ?? '0.00'}</Text>
-      <Text style={{ fontWeight:'700' }}>TOTAL: £{(order.totals_cents/100).toFixed(2)}</Text>
-    </ScrollView>
+    <SafeAreaView style={styles.safe} edges={['left', 'right']}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>{r?.items?.[0]?.name || 'Order'} — £{(order.totals_cents/100).toFixed(2)}</Text>
+        <Text style={styles.meta}>Code: {order.pickup_code}</Text>
+        <Text style={styles.meta}>{new Date(order.created_at).toLocaleString()}</Text>
+        <View style={{ height:12 }} />
+        {r?.items?.map((it, idx) => (
+          <View key={idx} style={styles.itemCard}>
+            <Text style={styles.itemTitle}>{it.quantity} × {it.name} — £{it.unitFinalPrice.toFixed(2)}</Text>
+            {it?.modifiers?.length ? it.modifiers.map((m, i) => (
+              <Text key={i} style={styles.modifier}>
+                • {m.type === 'extraShot' ? `+${m.count} shot${m.count>1?'s':''}` : m.label}
+                {m.priceDelta ? ` (+£${m.priceDelta.toFixed(2)})` : ''}
+              </Text>
+            )) : null}
+          </View>
+        ))}
+        <View style={{ height:8 }} />
+        <Text style={styles.meta}>Subtotal: £{r?.totals?.subtotal?.toFixed(2) ?? (order.totals_cents/100).toFixed(2)}</Text>
+        {(order?.free_drinks_redeemed || r?.freeDrinksUsed) ? (
+          <Text style={styles.meta}>Free drinks redeemed: {order?.free_drinks_redeemed || r?.freeDrinksUsed}</Text>
+        ) : null}
+        <Text style={styles.meta}>Tax: £{r?.totals?.tax?.toFixed(2) ?? '0.00'}</Text>
+        <Text style={styles.total}>TOTAL: £{(order.totals_cents/100).toFixed(2)}</Text>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: 'transparent' },
+  content: { padding: 16, paddingBottom: 40 },
+  title: { fontSize: 18, fontFamily: 'Fraunces_700Bold', color: palette.coffee },
+  meta: { marginTop: 4, color: palette.coffee, fontFamily: 'Fraunces_600SemiBold' },
+  itemCard: { borderWidth: 1, borderColor: palette.border, borderRadius: 12, padding: 12, marginBottom: 10, backgroundColor: palette.paper },
+  itemTitle: { fontFamily: 'Fraunces_600SemiBold', color: palette.coffee },
+  modifier: { color: palette.coffee, fontFamily: 'Fraunces_600SemiBold' },
+  total: { fontFamily: 'Fraunces_700Bold', color: palette.clay, marginTop: 8 },
+});

--- a/src/screens/OrdersScreen.tsx
+++ b/src/screens/OrdersScreen.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View, Text, FlatList, Pressable, StyleSheet } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { fetchUserOrders, subscribeUserOrders } from '../services/orders';
 import { palette } from '../design/theme';
 
 export default function OrdersScreen({ navigation }) {
   const [orders, setOrders] = useState<any[]>([]);
+  const insets = useSafeAreaInsets();
 
   const load = useCallback(async () => {
     try { setOrders(await fetchUserOrders()); } catch {}
@@ -46,13 +48,18 @@ export default function OrdersScreen({ navigation }) {
   };
 
   return (
-    <FlatList
-      contentContainerStyle={styles.content}
-      data={orders}
-      keyExtractor={(o) => o.id}
-      renderItem={renderItem}
-      ListEmptyComponent={<Text style={styles.empty}>No orders yet.</Text>}
-    />
+    <SafeAreaView style={styles.safe} edges={['left', 'right']}>
+      <View style={[styles.header, { paddingTop: insets.top }]}>
+        <Text style={styles.headerTitle}>Orders</Text>
+      </View>
+      <FlatList
+        contentContainerStyle={styles.content}
+        data={orders}
+        keyExtractor={(o) => o.id}
+        renderItem={renderItem}
+        ListEmptyComponent={<Text style={styles.empty}>No orders yet.</Text>}
+      />
+    </SafeAreaView>
   );
 }
 
@@ -64,7 +71,21 @@ const badgeStyle = (status: string) => ({
 });
 
 const styles = StyleSheet.create({
-  content: { padding: 16, paddingBottom: 24 },
+  safe: { flex: 1, backgroundColor: 'transparent' },
+  header: {
+    backgroundColor: palette.cream,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.15,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 4,
+    zIndex: 10,
+  },
+  headerTitle: { fontSize: 20, color: '#3E2723', fontFamily: 'Fraunces_700Bold' },
+  content: { padding: 16, paddingBottom: 120 },
   card: { backgroundColor: palette.paper, borderColor: palette.border, borderWidth: 1, borderRadius: 14, padding: 16, marginBottom: 14 },
   rowBetween: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   title: { fontSize: 16, color: palette.coffee, fontFamily: 'Fraunces_700Bold' },


### PR DESCRIPTION
## Summary
- Add SafeAreaView header to Orders screen so tiles aren't cut off
- Restyle receipt screen with palette colors and fonts to match global theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40fc8c6b08322b45781b1e540e1ed