### PR TITLE
feat: centralize currency formatting

### DIFF
--- a/src/components/MenuItemDetail.js
+++ b/src/components/MenuItemDetail.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Modal, View, Text, ScrollView, Pressable, StyleSheet } from 'react-native';
 import { palette } from '../design/theme';
 import { computeItemTotal } from '../services/menuData.js';
+import formatCurrency from '../utils/formatCurrency';
 
 export default function MenuItemDetail({ item, options, visible, onClose, onAdd }) {
   const [altMilk, setAltMilk] = useState(null);
@@ -104,7 +105,7 @@ export default function MenuItemDetail({ item, options, visible, onClose, onAdd 
               </View>
             )}
           </ScrollView>
-          <Text style={styles.price}>£{total.toFixed(2)}</Text>
+          <Text style={styles.price}>{formatCurrency(total)}</Text>
           <Pressable style={styles.addBtn} onPress={add}><Text style={styles.addTxt}>Add to cart</Text></Pressable>
           <Pressable style={styles.closeBtn} onPress={onClose}><Text style={styles.closeTxt}>Close</Text></Pressable>
         </View>

--- a/src/components/membership/MembershipSignedInPanel.js
+++ b/src/components/membership/MembershipSignedInPanel.js
@@ -6,6 +6,7 @@ import { palette } from '../../design/theme';
 import { supabase } from '../../lib/supabase';
 import { useNavigation } from '@react-navigation/native';
 import { getMemberQRCodes } from '../../services/qr';
+import formatCurrency from '../../utils/formatCurrency';
 
 function Stat({ label, value, prefix='', suffix='' }) {
   return (
@@ -56,12 +57,12 @@ export default function MembershipSignedInPanel({ summary, stats, user }) {
       {isPaid && (
         <View style={styles.gridRow}>
           <Stat label="Free drinks left" value={stats.freebiesLeft} />
-          <Stat label="Dividends pending" value={Number(stats.dividendsPending).toFixed(2)} prefix="£" />
+          <Stat label="Dividends pending" value={formatCurrency(Number(stats.dividendsPending))} />
         </View>
       )}
       <View style={styles.gridRow}>
         <Stat label="Loyalty stamps" value={`${stats.loyaltyStamps}/8`} />
-        <Stat label="Pay-it-forward" value={Number(stats.payItForwardContrib || 0).toFixed(2)} prefix="£" />
+        <Stat label="Pay-it-forward" value={formatCurrency(Number(stats.payItForwardContrib || 0))} />
       </View>
     </>
   );

--- a/src/components/membership/MembershipSignedOutPanel.js
+++ b/src/components/membership/MembershipSignedOutPanel.js
@@ -2,12 +2,13 @@
 import React from 'react';
 import { View, Text, StyleSheet, Pressable } from 'react-native';
 import { palette } from '../../design/theme';
+import formatCurrency from '../../utils/formatCurrency';
 
 export default function MembershipSignedOutPanel({ navigation }) {
   return (
     <>
       <View style={styles.infoCard}>
-        <Text style={styles.cardTitle}>Paid Membership — £20/month</Text>
+        <Text style={styles.cardTitle}>Paid Membership — {formatCurrency(20)}/month</Text>
         <Text style={styles.perk}>• Monthly free drinks allowance for members</Text>
         <Text style={styles.perk}>• Member dividends shared periodically</Text>
         <Text style={styles.perk}>• Continued loyalty stamps (9th drink free)</Text>

--- a/src/constants/membership.js
+++ b/src/constants/membership.js
@@ -1,7 +1,9 @@
+import formatCurrency from '../utils/formatCurrency';
+
 export const MEMBERSHIP = {
-  price: "£20/month",
+  price: `${formatCurrency(20)}/month`,
   perks: [
-    "3 free drinks each month (~£13.50 value)",
+    `3 free drinks each month (~${formatCurrency(13.5)} value)`,
     "10% discount on everything else",
     "Equal share of the 5% Member Pool (dividends when there's net profit)",
     "A community voice: collective vote on select issues"

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -6,6 +6,7 @@ import { useTabBarHeight } from '../navigation/TabBarHeightContext';
 import { CartContext } from '../context/CartContext';
 import { palette } from '../design/theme';
 import { buildReceipt, sendReceiptToPOS, printReceiptToConsole } from '../utils/receipt';
+import formatCurrency from '../utils/formatCurrency';
 import { saveReceiptForUser } from '../services/orders';
 import { useOrdersPresence } from '../context/OrdersContext';
 import { supabase } from '../lib/supabase';
@@ -144,7 +145,7 @@ export default function CartScreen({ navigation }) {
       <View style={styles.card}>
         <View style={styles.rowBetween}>
           <Text style={styles.itemName}>{item.name}</Text>
-          <Text style={styles.itemPrice}>£{(item.price * item.quantity).toFixed(2)}</Text>
+          <Text style={styles.itemPrice}>{formatCurrency(item.price * item.quantity)}</Text>
         </View>
         {(() => {
           const parts = [];
@@ -220,7 +221,7 @@ export default function CartScreen({ navigation }) {
       >
         <View style={styles.footerTopRow}>
           <Text style={styles.subtotalLabel}>Subtotal</Text>
-          <Text style={styles.subtotalValue}>£{subtotal.toFixed(2)}</Text>
+          <Text style={styles.subtotalValue}>{formatCurrency(subtotal)}</Text>
         </View>
 
         <View style={styles.voucherPanel}>

--- a/src/screens/CommunityScreen.js
+++ b/src/screens/CommunityScreen.js
@@ -3,6 +3,7 @@ import { View, Text, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { palette } from '../design/theme';
 import { getFundProgress, getFundHistory } from '../services/community';
+import formatCurrency from '../utils/formatCurrency';
 
 export default function CommunityScreen() {
   const insets = useSafeAreaInsets();
@@ -44,7 +45,7 @@ export default function CommunityScreen() {
             <View style={[styles.progressBarInner, { width: `${pct}%` }]} />
           </View>
           <Text style={styles.progressLabel}>
-            £{(progress.total_cents/100).toFixed(2)} raised of £{(progress.goal_cents/100).toFixed(2)} ({pct}%)
+            {formatCurrency(progress.total_cents/100)} raised of {formatCurrency(progress.goal_cents/100)} ({pct}%)
           </Text>
         </View>
       </View>
@@ -63,8 +64,8 @@ export default function CommunityScreen() {
           return (
             <View key={idx} style={styles.tableRow}>
               <Text style={[styles.cell, styles.cellMonth]}>{row.month}</Text>
-              <Text style={[styles.cell, styles.cellAmt]}>£{(row.total_cents/100).toFixed(2)}</Text>
-              <Text style={[styles.cell, styles.cellAmt]}>£{(row.goal_cents/100).toFixed(2)}</Text>
+              <Text style={[styles.cell, styles.cellAmt]}>{formatCurrency(row.total_cents/100)}</Text>
+              <Text style={[styles.cell, styles.cellAmt]}>{formatCurrency(row.goal_cents/100)}</Text>
               <View style={[styles.cell, styles.cellBar]}>
                 <View style={styles.miniBarOuter}>
                   <View style={[styles.miniBarInner, { width: `${Math.round(p*100)}%` }]} />

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -5,6 +5,7 @@ import { View, Text, StyleSheet, ScrollView, Pressable, Image, Animated, Touchab
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';
 import { palette } from '../design/theme';
+import formatCurrency from '../utils/formatCurrency';
 import GlowingGlassButton from '../components/GlowingGlassButton';
 import LoyaltyStampTile from '../components/LoyaltyStampTile';
 import FreeDrinksCounter from '../components/FreeDrinksCounter';
@@ -235,8 +236,8 @@ export default function HomeScreen({ navigation }) {
             <Text style={styles.cardTitle}>Community fund (this month)</Text>
             <ProgressBar value={fund?.total_cents || 0} max={(fund?.goal_cents || 0) || 1} />
             <Text style={styles.muted}>
-              £{((fund?.total_cents || 0) / 100).toFixed(2)}
-              {(fund?.goal_cents || 0) ? ` / £${((fund?.goal_cents || 0) / 100).toFixed(2)}` : ''}
+              {formatCurrency((fund?.total_cents || 0) / 100)}
+              {(fund?.goal_cents || 0) ? ` / ${formatCurrency((fund?.goal_cents || 0) / 100)}` : ''}
             </Text>
           </Pressable>
         </View>

--- a/src/screens/MembershipInfoScreen.js
+++ b/src/screens/MembershipInfoScreen.js
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { ScrollView, View, Text, StyleSheet } from 'react-native';
 import { palette } from '../design/theme';
 import GlowingGlassButton from '../components/GlowingGlassButton';
+import formatCurrency from '../utils/formatCurrency';
 
 export default function MembershipInfoScreen({ navigation }) {
   const scrollRef = useRef(null);
@@ -33,7 +34,7 @@ export default function MembershipInfoScreen({ navigation }) {
         </View>
 
         <View style={styles.card}>
-          <Text style={styles.tierTitle}>Member — £20/month</Text>
+          <Text style={styles.tierTitle}>Member — {formatCurrency(20)}/month</Text>
           <Text style={styles.desc}>• 3 free drinks every month.</Text>
           <Text style={styles.desc}>• 10% discount after free drinks are used.</Text>
           <Text style={styles.desc}>• Share of 5% “Member Pool” (periodic dividends*)</Text>

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -19,6 +19,7 @@ import 'react-native-get-random-values';
 import FreeDrinksCounter from '../components/FreeDrinksCounter';
 import LoyaltyStampTile from '../components/LoyaltyStampTile';
 import { applyStampAccrual } from '../utils/rewards';
+import formatCurrency from '../utils/formatCurrency';
 
 function Stat({ label, value, prefix = '', suffix = '', style }) {
   return (
@@ -231,12 +232,12 @@ export default function MembershipScreen({ navigation }) {
 
             {summary.tier === 'paid' ? (
               <View style={styles.gridRow}>
-                <Stat label="Dividends pending" value={Number(stats?.dividendsPending || 0).toFixed(2)} prefix="£" />
-                <Stat label="Pay-it-forward" value={(pifSelfCents / 100).toFixed(2)} prefix="£" />
+                <Stat label="Dividends pending" value={formatCurrency(Number(stats?.dividendsPending || 0))} />
+                <Stat label="Pay-it-forward" value={formatCurrency(pifSelfCents / 100)} />
               </View>
             ) : (
               <View style={{ marginTop: 14 }}>
-                <Stat label="Pay-it-forward" value={(pifSelfCents / 100).toFixed(2)} prefix="£" style={{ marginRight: 0 }} />
+                <Stat label="Pay-it-forward" value={formatCurrency(pifSelfCents / 100)} style={{ marginRight: 0 }} />
               </View>
             )}
 
@@ -263,7 +264,7 @@ export default function MembershipScreen({ navigation }) {
         ) : (
           <>
             <View style={styles.infoCard}>
-              <Text style={styles.cardTitle}>Paid Membership — £20/month</Text>
+              <Text style={styles.cardTitle}>Paid Membership — {formatCurrency(20)}/month</Text>
               <Text style={styles.perk}>• Monthly free drinks allowance for members</Text>
               <Text style={styles.perk}>• Member dividends shared periodically</Text>
               <Text style={styles.perk}>• Continued loyalty stamps (9th drink free)</Text>

--- a/src/screens/MembershipStartScreen.js
+++ b/src/screens/MembershipStartScreen.js
@@ -8,6 +8,7 @@ import GlowingGlassButton from '../components/GlowingGlassButton';
 import { supabase, hasSupabase } from '../lib/supabase';
 import { useNavigation } from '@react-navigation/native';
 import { redeemReferral } from '../services/referral';
+import formatCurrency from '../utils/formatCurrency';
 
 const Seg = ({ value, setValue }) => (
   <View style={styles.segWrap}>
@@ -27,7 +28,7 @@ const TierToggle = ({ tier, setTier }) => (
   <View style={styles.tierWrap}>
     {[
       { key: 'free', label: 'Loyalty card (Free)' },
-      { key: 'paid', label: 'Member (£20/mo)' },
+      { key: 'paid', label: `Member (${formatCurrency(20)}/mo)` },
     ].map(({ key, label }) => {
       const active = tier === key;
       return (
@@ -139,7 +140,7 @@ export default function MembershipStartScreen() {
               ) : (
                 <>
                   <View style={styles.priceRow}>
-                    <Text style={styles.priceValue}>£20</Text>
+                    <Text style={styles.priceValue}>{formatCurrency(20)}</Text>
                     <Text style={styles.perMonth}>/month</Text>
                   </View>
                   <Text style={styles.perkTitle}>What you get</Text>

--- a/src/screens/MenuScreen.js
+++ b/src/screens/MenuScreen.js
@@ -17,6 +17,7 @@ import { useCart } from '../context/CartContext';
 import { supabase } from '../lib/supabase';
 import { useNavigation } from '@react-navigation/native';
 import MenuItemDetail from '../components/MenuItemDetail';
+import formatCurrency from '../utils/formatCurrency';
 
 export default function MenuScreen() {
   const insets = useSafeAreaInsets();
@@ -76,7 +77,7 @@ export default function MenuScreen() {
   const renderItem = ({ item }) => (
     <Pressable style={styles.itemCard} onPress={() => setSelected(item)}>
       <Text style={styles.itemName}>{item.name}</Text>
-      <Text style={styles.itemPrice}>£{item.price?.toFixed(2)}</Text>
+      <Text style={styles.itemPrice}>{formatCurrency(item.price ?? 0)}</Text>
     </Pressable>
   );
 

--- a/src/screens/OrderDetailScreen.tsx
+++ b/src/screens/OrderDetailScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ScrollView, View, Text, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { palette } from '../design/theme';
+import formatCurrency from '../utils/formatCurrency';
 
 export default function OrderDetailScreen({ route }) {
   const { order } = route.params;
@@ -9,28 +10,28 @@ export default function OrderDetailScreen({ route }) {
   return (
     <SafeAreaView style={styles.safe} edges={['left', 'right']}>
       <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.title}>{r?.items?.[0]?.name || 'Order'} — £{(order.totals_cents/100).toFixed(2)}</Text>
+        <Text style={styles.title}>{r?.items?.[0]?.name || 'Order'} — {formatCurrency(order.totals_cents/100)}</Text>
         <Text style={styles.meta}>Code: {order.pickup_code}</Text>
         <Text style={styles.meta}>{new Date(order.created_at).toLocaleString()}</Text>
         <View style={{ height:12 }} />
         {r?.items?.map((it, idx) => (
           <View key={idx} style={styles.itemCard}>
-            <Text style={styles.itemTitle}>{it.quantity} × {it.name} — £{it.unitFinalPrice.toFixed(2)}</Text>
+            <Text style={styles.itemTitle}>{it.quantity} × {it.name} — {formatCurrency(it.unitFinalPrice)}</Text>
             {it?.modifiers?.length ? it.modifiers.map((m, i) => (
               <Text key={i} style={styles.modifier}>
                 • {m.type === 'extraShot' ? `+${m.count} shot${m.count>1?'s':''}` : m.label}
-                {m.priceDelta ? ` (+£${m.priceDelta.toFixed(2)})` : ''}
+                {m.priceDelta ? ` (+${formatCurrency(m.priceDelta)})` : ''}
               </Text>
             )) : null}
           </View>
         ))}
         <View style={{ height:8 }} />
-        <Text style={styles.meta}>Subtotal: £{r?.totals?.subtotal?.toFixed(2) ?? (order.totals_cents/100).toFixed(2)}</Text>
+        <Text style={styles.meta}>Subtotal: {formatCurrency(r?.totals?.subtotal ?? (order.totals_cents/100))}</Text>
         {(order?.free_drinks_redeemed || r?.freeDrinksUsed) ? (
           <Text style={styles.meta}>Free drinks redeemed: {order?.free_drinks_redeemed || r?.freeDrinksUsed}</Text>
         ) : null}
-        <Text style={styles.meta}>Tax: £{r?.totals?.tax?.toFixed(2) ?? '0.00'}</Text>
-        <Text style={styles.total}>TOTAL: £{(order.totals_cents/100).toFixed(2)}</Text>
+        <Text style={styles.meta}>Tax: {formatCurrency(r?.totals?.tax ?? 0)}</Text>
+        <Text style={styles.total}>TOTAL: {formatCurrency(order.totals_cents/100)}</Text>
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/screens/OrdersScreen.tsx
+++ b/src/screens/OrdersScreen.tsx
@@ -4,6 +4,7 @@ import { useFocusEffect } from '@react-navigation/native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { fetchUserOrders, subscribeUserOrders } from '../services/orders';
 import { palette } from '../design/theme';
+import formatCurrency from '../utils/formatCurrency';
 
 export default function OrdersScreen({ navigation }) {
   const [orders, setOrders] = useState<any[]>([]);
@@ -31,7 +32,7 @@ export default function OrdersScreen({ navigation }) {
       <Pressable style={styles.card} onPress={() => navigation.navigate('OrderDetail', { order: item })}>
         <View style={styles.rowBetween}>
           <Text style={styles.title}>{subtitle}</Text>
-          <Text style={styles.total}>{`£${total.toFixed(2)}`}</Text>
+          <Text style={styles.total}>{formatCurrency(total)}</Text>
         </View>
         <View style={styles.rowBetween}>
           <Text style={styles.muted}>{when.toLocaleString()}</Text>

--- a/src/utils/formatCurrency.ts
+++ b/src/utils/formatCurrency.ts
@@ -1,0 +1,11 @@
+const formatter = new Intl.NumberFormat('en-GB', {
+  style: 'currency',
+  currency: 'GBP',
+});
+
+export function formatCurrency(value: number): string {
+  return formatter.format(value);
+}
+
+export default formatCurrency;
+

--- a/src/utils/receipt.ts
+++ b/src/utils/receipt.ts
@@ -1,4 +1,6 @@
 
+import formatCurrency from './formatCurrency.js';
+
 export type ReceiptItemModifier =
   | { type: 'altMilk'; label: string; priceDelta: number }
   | { type: 'syrup'; label: string; priceDelta: number }
@@ -175,25 +177,25 @@ export function printReceiptToConsole(receipt: Receipt): void {
   lines.push(`When: ${formatTimeRange(receipt.timeSlot.startISO, receipt.timeSlot.endISO)}`);
   lines.push('');
   receipt.items.forEach((item) => {
-    lines.push(`${item.quantity} × ${item.name}  £${item.unitFinalPrice.toFixed(2)}`);
+    lines.push(`${item.quantity} × ${item.name}  ${formatCurrency(item.unitFinalPrice)}`);
     item.modifiers.forEach((m) => {
       if (m.type === 'altMilk') lines.push(`   • ${m.label}`);
-      if (m.type === 'syrup') lines.push(`   • ${m.label} (+£${m.priceDelta.toFixed(2)})`);
+      if (m.type === 'syrup') lines.push(`   • ${m.label} (+${formatCurrency(m.priceDelta)})`);
       if (m.type === 'coffeeBlend') lines.push(`   • ${m.label}`);
-      if (m.type === 'extraShot') lines.push(`   • +${m.count} shot${m.count > 1 ? 's' : ''} (+£${(m.priceDelta * m.count).toFixed(2)})`);
+      if (m.type === 'extraShot') lines.push(`   • +${m.count} shot${m.count > 1 ? 's' : ''} (+${formatCurrency(m.priceDelta * m.count)})`);
     });
-    lines.push(`   = £${item.lineTotal.toFixed(2)}`);
+    lines.push(`   = ${formatCurrency(item.lineTotal)}`);
     lines.push('');
   });
-  lines.push(`Subtotal: £${receipt.totals.subtotal.toFixed(2)}`);
+  lines.push(`Subtotal: ${formatCurrency(receipt.totals.subtotal)}`);
   if (receipt.vouchersRedeemed) {
-    lines.push(`Vouchers used: ${receipt.vouchersRedeemed} (−£${receipt.totals.discounts.toFixed(2)})`);
+    lines.push(`Vouchers used: ${receipt.vouchersRedeemed} (−${formatCurrency(receipt.totals.discounts)})`);
   }
   if (receipt.totals.pifContribution) {
-    lines.push(`PIF: £${receipt.totals.pifContribution.toFixed(2)}`);
+    lines.push(`PIF: ${formatCurrency(receipt.totals.pifContribution)}`);
   }
-  lines.push(`Tax: £${receipt.totals.tax.toFixed(2)}`);
-  lines.push(`TOTAL: £${receipt.totals.grandTotal.toFixed(2)}`);
+  lines.push(`Tax: ${formatCurrency(receipt.totals.tax)}`);
+  lines.push(`TOTAL: ${formatCurrency(receipt.totals.grandTotal)}`);
   console.log(lines.join('\n'));
   console.log('=== RECEIPT JSON ===');
   console.log(JSON.stringify(receipt, null, 2));


### PR DESCRIPTION
## Summary
- add `formatCurrency` helper for GBP values
- replace manual string formatting with helper across screens and utils
- standardize membership price strings using the helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b411e0e5ac832286efb1737b2cfad4