### PR TITLE
feat(orders): include source in order row

### DIFF
--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -8,20 +8,19 @@ export async function saveReceiptForUser(userId: string, receipt: Receipt, freeD
   const { source, source_meta } = normalizeSource((receipt as any)?.source);
 
   console.log('[ORDERS] normalizeSource', (receipt as any)?.source, '→', source, source_meta);
-
-
-  const row = buildOrderRow({
-    userId,
-    orderId: receipt.orderId,
-    totalsCents,
-    currency: receipt?.totals?.currency || 'GBP',
-    items: receipt.items,
-    receipt,
-
+  const row = {
+    ...buildOrderRow({
+      userId,
+      orderId: receipt.orderId,
+      totalsCents,
+      currency: receipt?.totals?.currency || 'GBP',
+      items: receipt.items,
+      receipt,
+      source,
+      source_meta,
+    }),
     free_drinks_redeemed: freeDrinksRedeemed,
-  },
-
-
+  };
   const { data, error } = await supabase
     .from('orders')
     .insert(row)


### PR DESCRIPTION
## Summary
- build order rows with source metadata and free drink redemption count

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b41210f9cc8322b83e9e800e5310f6