### PR TITLE
refactor: schedule loading signals post commit

### DIFF
--- a/src/boot/loadingSignals.ts
+++ b/src/boot/loadingSignals.ts
@@ -1,3 +1,5 @@
+import { InteractionManager } from 'react-native';
+
 type Keys = 'auth' | 'stamps' | 'cms';
 type Listener = (state: Record<Keys, boolean>) => void;
 
@@ -52,13 +54,14 @@ function notify() {
 }
 
 function scheduleNotify() {
-  if (typeof requestAnimationFrame === 'function') {
-    // Delay until next frame so React isn't mid-insertion effect when listeners update state
-    requestAnimationFrame(() => notify());
-  } else {
-    setTimeout(notify, 0);
-  }
-
+  // Defer until after commit so React isn't mid-insertion effect when listeners update state
+  setTimeout(() => {
+    if (typeof InteractionManager?.runAfterInteractions === 'function') {
+      InteractionManager.runAfterInteractions(() => notify());
+    } else {
+      notify();
+    }
+  }, 0);
 }
 
 // Optional: for manual marking from code instead of console text


### PR DESCRIPTION
## Summary
- defer loading signal notifications until after commit to avoid insertion effects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bf11b2448322975257ffa5619d1d