### PR TITLE
Refresh stats after voucher redemption

### DIFF
--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { View, Text, FlatList, StyleSheet, TouchableOpacity, Alert, Modal, Pressable, ScrollView } from 'react-native';
+import { View, Text, FlatList, StyleSheet, TouchableOpacity, Alert, Modal, Pressable, ScrollView, Platform, ToastAndroid } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Swipeable } from 'react-native-gesture-handler';
 import { useTabBarHeight } from '../navigation/TabBarHeightContext';
@@ -21,6 +21,14 @@ export default function CartScreen({ navigation }) {
     useStats?.() || { stats: { freebiesLeft: 0 }, refreshStats: async () => {} };
   const freeDrinks = stats?.freebiesLeft ?? 0;
   const { setHasOrders, refreshOrdersPresence } = useOrdersPresence();
+
+  const showToast = (msg) => {
+    if (Platform.OS === 'android') {
+      ToastAndroid.show(msg, ToastAndroid.SHORT);
+    } else {
+      Alert.alert(msg);
+    }
+  };
 
   const tabBarHeight = useTabBarHeight();
   // Be defensive about what's available in CartContext
@@ -319,9 +327,9 @@ export default function CartScreen({ navigation }) {
 
 
               try {
-                await refreshStats();
+                await refreshStats(true);
               } catch (e) {
-                console.warn('[LOYALTY] refreshStats failed', e);
+                showToast('Failed to refresh stats');
               }
               try {
                 await getMembershipSummary?.();

--- a/src/screens/ScanScreen.js
+++ b/src/screens/ScanScreen.js
@@ -1,7 +1,17 @@
 
 import React from 'react';
-import { View, Text, Button } from 'react-native';
+import { View, Text, Button, Platform, ToastAndroid, Alert } from 'react-native';
 import { supabase } from '../lib/supabase';
+import { redeemVoucher } from '../services/vouchers';
+import { useStats } from '../hooks/useStats';
+
+function showToast(msg) {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(msg, ToastAndroid.SHORT);
+  } else {
+    Alert.alert(msg);
+  }
+}
 
 async function loadScanner() {
   try { const m = await import('expo-barcode-scanner'); return m.BarCodeScanner; }
@@ -13,6 +23,7 @@ async function loadScanner() {
     const [status,setStatus]=React.useState(null);
     const [loading,setLoading]=React.useState(true);
     const [info,setInfo]=React.useState(null);
+    const { refreshStats } = useStats();
 
   React.useEffect(()=>{
     let on=true;
@@ -45,8 +56,17 @@ async function loadScanner() {
                   setInfo(res);
                 } else if(content.startsWith('voucher:')){
                   const voucher_code=content.slice('voucher:'.length);
-                  const { data: res } = await supabase.functions.invoke('member-lookup',{ body:{ voucher_code } });
-                  setInfo(res);
+                  try {
+                    const ok = await redeemVoucher(voucher_code, refreshStats);
+                    if (!ok) {
+                      showToast('Invalid voucher');
+                      return;
+                    }
+                    const { data: res } = await supabase.functions.invoke('member-lookup',{ body:{ voucher_code } });
+                    setInfo(res);
+                  } catch {
+                    showToast('Failed to refresh stats');
+                  }
                 }
               } catch(err){ console.log('lookup failed', err); }
             }}

--- a/src/services/vouchers.js
+++ b/src/services/vouchers.js
@@ -12,13 +12,13 @@ export async function syncVouchers() {
   }
 }
 
-export async function redeemVoucher(code) {
+export async function redeemVoucher(code, refreshStats) {
   if (!hasSupabase || !supabase) return false;
-  try {
-    const { data, error } = await supabase.functions.invoke('voucher-redeem', { body: { code } });
-    if (error) return false;
-    return data?.success ?? false;
-  } catch {
-    return false;
+  const { data, error } = await supabase.functions.invoke('voucher-redeem', { body: { code } });
+  if (error) return false;
+  const success = data?.success ?? false;
+  if (success && typeof refreshStats === 'function') {
+    await refreshStats(true);
   }
+  return success;
 }


### PR DESCRIPTION
## Summary
- refresh loyalty stats after voucher redemption
- notify users when stat refresh fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bf3b16008322b19429d33c2065be