### PR TITLE
Handle loyalty totals defensively

### DIFF
--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -314,10 +314,14 @@ export default function CartScreen({ navigation }) {
                 if (error) {
                   console.warn('[LOYALTY] checkout_loyalty failed:', error);
                 } else {
-                  const [row] = Array.isArray(data) ? data : [];
+                  const row = Array.isArray(data) ? data[0] : data;
+                  const loyaltyStamps =
+                    row && row.loyalty_stamps != null ? row.loyalty_stamps : null;
+                  const freeDrinksTotal =
+                    row && row.free_drinks != null ? row.free_drinks : null;
 
                   console.log(
-                    `[LOYALTY] awarded ${stampsToAward}, redeemed ${redeemCount} → totals: stamps=${row?.loyalty_stamps}, free_drinks=${row?.free_drinks}`
+                    `[LOYALTY] awarded ${stampsToAward}, redeemed ${redeemCount} → totals: stamps=${loyaltyStamps}, free_drinks=${freeDrinksTotal}`
                   );
 
                 }


### PR DESCRIPTION
## Summary
- Safely handle checkout_loyalty results by accepting array or object responses
- Log loyalty totals with null checks to avoid undefined values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c1c1ef9c8322893cb663d2f21601