### PR TITLE
Defer initial loading signal callbacks until after interactions

### DIFF
--- a/src/boot/loadingSignals.ts
+++ b/src/boot/loadingSignals.ts
@@ -38,7 +38,13 @@ export function patchConsoleForLoadingSignals() {
 
 export function subscribe(fn: Listener) {
   listeners.add(fn);
-  const t = setTimeout(() => fn({ ...state }), 0);
+  const t = setTimeout(() => {
+    if (typeof InteractionManager?.runAfterInteractions === 'function') {
+      InteractionManager.runAfterInteractions(() => fn({ ...state }));
+    } else {
+      fn({ ...state });
+    }
+  }, 0);
   return () => {
     listeners.delete(fn);
     clearTimeout(t);


### PR DESCRIPTION
## Summary
- Wrap loading signal subscription callback with InteractionManager.runAfterInteractions so state updates occur only after React commit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c228e6fc8322b56af591fe95fed3