### PR TITLE
feat: sync rewards profile aggregates

### DIFF
--- a/supabase/functions/_shared/rewards.ts
+++ b/supabase/functions/_shared/rewards.ts
@@ -68,6 +68,30 @@ export async function normalizeRewards(admin: SupabaseClient, userId: string) {
     }
   }
 
+  // Sync aggregates to public.profiles.{loyalty_stamps, free_drinks}
+  let pk = "id";
+  const { error: userIdColErr } = await admin
+    .from("profiles")
+    .select("user_id")
+    .limit(1);
+  if (!userIdColErr) {
+    pk = "user_id";
+  } else {
+    const { error: idColErr } = await admin
+      .from("profiles")
+      .select("id")
+      .limit(1);
+    if (idColErr) throw idColErr;
+  }
+  const { error: profileErr } = await admin
+    .from("profiles")
+    .update({
+      loyalty_stamps: stampsRemainder,
+      free_drinks: unredeemed?.length ?? 0,
+    })
+    .eq(pk, userId);
+  if (profileErr) throw profileErr;
+
   console.log("[ME_STATS]", {
     totalStamps,
     vouchersEarned,


### PR DESCRIPTION
## Summary
- sync loyalty stamp totals and free drink counts into public.profiles

## Testing
- `npm test`
- `supabase db reset` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ca8f4df8832291c8ffdc0143d038