### PR TITLE
Update stats after loyalty checkout

### DIFF
--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -6,6 +6,7 @@ import { applyStampAccrual } from '../utils/rewards';
 export const StatsContext = createContext({
   stats: { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] },
   refreshStats: async () => ({ loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] }),
+  setStats: () => {},
 });
 
 export function StatsProvider({ children }) {
@@ -15,50 +16,57 @@ export function StatsProvider({ children }) {
       freebiesLeft: 0,
       vouchers: [],
     };
-  const [stats, setStats] = useState(initial);
+  const [stats, setStatsState] = useState(initial);
 
-  const refreshStats = useCallback(async (force = false) => {
-    if (!force && globalThis.preloaded?.stats) {
-      setStats(globalThis.preloaded.stats);
-      return globalThis.preloaded.stats;
-    }
-    try {
-      let s = await getMyStats();
-      const mismatch =
-        s.freebiesLeft !== (Array.isArray(s.vouchers) ? s.vouchers.length : 0);
-      const outOfRange = s.loyaltyStamps < 0 || s.loyaltyStamps > 7;
-      if (mismatch || outOfRange) {
-        await syncVouchers();
-        s = await getMyStats();
-      }
-      if (s.loyaltyStamps < 0 || s.loyaltyStamps > 7) {
-        const { vouchersEarned, stampsRemainder } = applyStampAccrual(
-          0,
-          s.loyaltyStamps,
-        );
-        s.loyaltyStamps = stampsRemainder;
-        if (vouchersEarned > 0) {
-          s.freebiesLeft += vouchersEarned;
-          s.vouchers = Array.isArray(s.vouchers) ? s.vouchers : [];
-        }
-      }
-      setStats(s);
-      globalThis.freebiesLeft = s.freebiesLeft;
-      globalThis.loyaltyStamps = s.loyaltyStamps;
-      globalThis.preloaded = globalThis.preloaded || {};
-      globalThis.preloaded.stats = s;
-      console.log('loyalty stamps and free drinks have been received');
-      return s;
-    } catch {
-      const fallback = { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
-      setStats(fallback);
-      return fallback;
-    }
+  const applyStats = useCallback((s) => {
+    setStatsState(s);
+    globalThis.freebiesLeft = s.freebiesLeft;
+    globalThis.loyaltyStamps = s.loyaltyStamps;
+    globalThis.preloaded = globalThis.preloaded || {};
+    globalThis.preloaded.stats = s;
   }, []);
 
+  const refreshStats = useCallback(
+    async (force = false) => {
+      if (!force && globalThis.preloaded?.stats) {
+        applyStats(globalThis.preloaded.stats);
+        return globalThis.preloaded.stats;
+      }
+      try {
+        let s = await getMyStats();
+        const mismatch =
+          s.freebiesLeft !== (Array.isArray(s.vouchers) ? s.vouchers.length : 0);
+        const outOfRange = s.loyaltyStamps < 0 || s.loyaltyStamps > 7;
+        if (mismatch || outOfRange) {
+          await syncVouchers();
+          s = await getMyStats();
+        }
+        if (s.loyaltyStamps < 0 || s.loyaltyStamps > 7) {
+          const { vouchersEarned, stampsRemainder } = applyStampAccrual(
+            0,
+            s.loyaltyStamps,
+          );
+          s.loyaltyStamps = stampsRemainder;
+          if (vouchersEarned > 0) {
+            s.freebiesLeft += vouchersEarned;
+            s.vouchers = Array.isArray(s.vouchers) ? s.vouchers : [];
+          }
+        }
+        applyStats(s);
+        console.log('loyalty stamps and free drinks have been received');
+        return s;
+      } catch {
+        const fallback = { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+        applyStats(fallback);
+        return fallback;
+      }
+    },
+    [applyStats],
+  );
+
   const value = useMemo(
-    () => ({ stats, refreshStats }),
-    [stats, refreshStats],
+    () => ({ stats, refreshStats, setStats: applyStats }),
+    [stats, refreshStats, applyStats],
   );
 
   return (

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -14,13 +14,15 @@ import { StatsContext } from '../context/StatsContext';
 import { getMembershipSummary } from '../services/membership';
 import { getToday } from '../services/homeData';
 import { checkoutLoyalty } from '../services/loyalty';
+import { syncVouchers } from '../services/vouchers';
 
 export default function CartScreen({ navigation }) {
   const insets = useSafeAreaInsets();
-  const { stats = { freebiesLeft: 0 }, refreshStats } =
+  const { stats = { freebiesLeft: 0 }, refreshStats, setStats } =
     useContext(StatsContext) || {
       stats: { freebiesLeft: 0 },
       refreshStats: async () => {},
+      setStats: () => {},
     };
   const freeDrinks = stats?.freebiesLeft ?? 0;
   const { setHasOrders, refreshOrdersPresence } = useOrdersPresence();
@@ -309,19 +311,32 @@ export default function CartScreen({ navigation }) {
               if (userId) {
                 // checkoutLoyalty mutates server totals; getMyStats (via refreshStats)
                 // is the single source of truth for loyalty values
-                const { error } = await checkoutLoyalty(
+                const { data, error } = await checkoutLoyalty(
                   userId,
                   canonical.orderId,
                   stampsToAward,
-                  redeemCount
+                  redeemCount,
                 );
 
                 if (error) {
                   console.warn('[LOYALTY] checkout_loyalty failed:', error);
-                } else if (__DEV__) {
-                  console.log(
-                    `[LOYALTY] awarded ${stampsToAward}, redeemed ${redeemCount}`
-                  );
+                } else {
+                  let vouchers = [];
+                  try {
+                    vouchers = await syncVouchers();
+                  } catch {
+                    vouchers = stats?.vouchers || [];
+                  }
+                  setStats({
+                    loyaltyStamps: data?.loyalty_stamps ?? 0,
+                    freebiesLeft: data?.free_drinks ?? 0,
+                    vouchers,
+                  });
+                  if (__DEV__) {
+                    console.log(
+                      `[LOYALTY] awarded ${stampsToAward}, redeemed ${redeemCount}`,
+                    );
+                  }
                 }
               } else if (__DEV__) {
                 console.log('[LOYALTY] no stamps awarded (no user).');


### PR DESCRIPTION
## Summary
- expose `setStats` in `StatsContext` to allow manual updates
- capture checkout loyalty data and immediately apply new stamp, free drink, and voucher totals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4cddba0f08322a798f355a3f334ed