### PR TITLE
Normalize loyalty rewards

### DIFF
--- a/scripts/normalize-all-rewards.js
+++ b/scripts/normalize-all-rewards.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import crypto from 'node:crypto';
+import { createAdminClient } from './_supabase.js';
+import { applyStampAccrual } from '../src/utils/rewards.js';
+
+const supabase = createAdminClient();
+
+async function listAllUserIds() {
+  const ids = [];
+  let page = 1;
+  for (;;) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage: 1000 });
+    if (error) throw error;
+    const users = data?.users ?? [];
+    if (!users.length) break;
+    ids.push(...users.map(u => u.id));
+    page++;
+  }
+  return ids;
+}
+
+const userIds = await listAllUserIds();
+
+for (const uid of userIds) {
+  const { data: stampAgg, error: stampErr } = await supabase
+    .from('loyalty_stamps')
+    .select('sum:stamps')
+    .eq('user_id', uid)
+    .single();
+  if (stampErr) throw stampErr;
+  const totalStamps = stampAgg?.sum ?? 0;
+
+  const { data: vouchers, error: vouchersErr } = await supabase
+    .from('drink_vouchers')
+    .select('id')
+    .eq('user_id', uid);
+  if (vouchersErr) throw vouchersErr;
+  const existing = vouchers?.length ?? 0;
+
+  const { vouchersEarned, stampsRemainder } = applyStampAccrual(0, totalStamps);
+  const toAdd = vouchersEarned - existing;
+  if (toAdd > 0) {
+    const rows = Array.from({ length: toAdd }, () => ({
+      user_id: uid,
+      code: crypto.randomUUID(),
+    }));
+    const { error: insErr } = await supabase.from('drink_vouchers').insert(rows);
+    if (insErr) throw insErr;
+  }
+
+  if (totalStamps !== stampsRemainder) {
+    const { error: delErr } = await supabase.from('loyalty_stamps').delete().eq('user_id', uid);
+    if (delErr) throw delErr;
+    if (stampsRemainder > 0) {
+      const { error: insErr2 } = await supabase
+        .from('loyalty_stamps')
+        .insert({ user_id: uid, stamps: stampsRemainder });
+      if (insErr2) throw insErr2;
+    }
+  }
+
+  const { data: unredeemed, error: unredeemedErr } = await supabase
+    .from('drink_vouchers')
+    .select('id')
+    .eq('user_id', uid)
+    .eq('redeemed', false);
+  if (unredeemedErr) throw unredeemedErr;
+
+  let pk = 'id';
+  const { error: userIdColErr } = await supabase.from('profiles').select('user_id').limit(1);
+  if (!userIdColErr) pk = 'user_id';
+
+  const { error: profileErr } = await supabase
+    .from('profiles')
+    .update({ loyalty_stamps: stampsRemainder, free_drinks: unredeemed.length })
+    .eq(pk, uid);
+  if (profileErr) throw profileErr;
+
+  console.log(`[SCRIPT] Normalized rewards for user ${uid}`);
+}
+

--- a/supabase/migrations/0016_normalize_rewards.sql
+++ b/supabase/migrations/0016_normalize_rewards.sql
@@ -1,0 +1,81 @@
+-- 0016_normalize_rewards.sql
+-- Normalize loyalty_stamps into drink_vouchers and cap per-user remainder at <8
+
+DO $$
+DECLARE
+  cnt int;
+BEGIN
+  -- ensure required tables exist
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='loyalty_stamps'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema='public' AND table_name='drink_vouchers'
+  ) THEN
+    RAISE NOTICE 'Skipping rewards normalization: required tables missing.';
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*) INTO cnt FROM public.loyalty_stamps;
+  IF cnt = 0 THEN
+    RAISE NOTICE 'Skipping rewards normalization: no rows in public.loyalty_stamps.';
+    RETURN;
+  END IF;
+
+  CREATE TEMP TABLE tmp_norm AS
+  SELECT ls.user_id,
+         SUM(ls.stamps)::int AS total_stamps
+  FROM public.loyalty_stamps ls
+  GROUP BY ls.user_id;
+
+  ALTER TABLE tmp_norm
+    ADD COLUMN vouchers_total int,
+    ADD COLUMN remainder int,
+    ADD COLUMN existing_vouchers int DEFAULT 0,
+    ADD COLUMN vouchers_to_add int;
+
+  UPDATE tmp_norm
+    SET vouchers_total = total_stamps / 8,
+        remainder = total_stamps % 8;
+
+  UPDATE tmp_norm t
+    SET existing_vouchers = dv.cnt
+    FROM (
+      SELECT user_id, COUNT(*) AS cnt FROM public.drink_vouchers GROUP BY user_id
+    ) dv
+    WHERE dv.user_id = t.user_id;
+
+  UPDATE tmp_norm
+    SET vouchers_to_add = vouchers_total - existing_vouchers;
+
+  -- insert missing vouchers
+  INSERT INTO public.drink_vouchers(user_id, code)
+    SELECT t.user_id, gen_random_uuid()::text
+    FROM tmp_norm t,
+         LATERAL generate_series(1, GREATEST(t.vouchers_to_add,0));
+
+  -- replace loyalty_stamps with remainder
+  DELETE FROM public.loyalty_stamps;
+  INSERT INTO public.loyalty_stamps(user_id, stamps)
+    SELECT user_id, remainder FROM tmp_norm WHERE remainder > 0;
+
+  -- acceptance: ensure no user ends with more than 7 stamps
+  IF EXISTS (SELECT 1 FROM public.loyalty_stamps WHERE stamps > 7) THEN
+    RAISE EXCEPTION 'normalize_rewards: user ends with >7 stamps';
+  END IF;
+
+  -- acceptance: voucher counts match expectations
+  IF EXISTS (
+    SELECT 1
+    FROM tmp_norm t
+    LEFT JOIN (
+      SELECT user_id, COUNT(*) AS cnt FROM public.drink_vouchers GROUP BY user_id
+    ) dv ON dv.user_id = t.user_id
+    WHERE COALESCE(dv.cnt,0) <> (t.total_stamps - t.remainder)/8
+  ) THEN
+    RAISE EXCEPTION 'normalize_rewards: voucher count mismatch';
+  END IF;
+
+  DROP TABLE tmp_norm;
+END $$;


### PR DESCRIPTION
## Summary
- Convert accumulated loyalty stamps into vouchers via new SQL migration
- Add admin script to normalize rewards across all users

## Testing
- `npm test`
- `node scripts/normalize-all-rewards.js` *(fails: Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b538861e308322a18a6751526133fa