### PR TITLE
fix: handle users without stamp history

### DIFF
--- a/scripts/normalize-all-rewards.js
+++ b/scripts/normalize-all-rewards.js
@@ -27,7 +27,7 @@ for (const uid of userIds) {
     .from('loyalty_stamps')
     .select('sum:stamps')
     .eq('user_id', uid)
-    .single();
+    .maybeSingle();
   if (stampErr) throw stampErr;
   const totalStamps = stampAgg?.sum ?? 0;
 


### PR DESCRIPTION
## Summary
- tolerate missing loyalty stamp rows when normalizing rewards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b53b92dfdc8322a1394fc679452b7d