### PR TITLE
Force fresh stats after voucher redemptions and checkout

### DIFF
--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -27,11 +27,7 @@ export function StatsProvider({ children }) {
   }, []);
 
   const refreshStats = useCallback(
-    async (force = false) => {
-      if (!force && globalThis.preloaded?.stats) {
-        applyStats(globalThis.preloaded.stats);
-        return globalThis.preloaded.stats;
-      }
+    async () => {
       try {
         let s = await getMyStats();
         const mismatch =

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -79,7 +79,7 @@ export default function CartScreen({ navigation }) {
   useEffect(() => {
     (async () => {
       try { const t = await getToday(); setTodayHours(t); } catch {}
-      try { await refreshStats(); } catch {}
+      try { await refreshStats(true); } catch {}
     })();
   }, [refreshStats]);
 

--- a/src/services/vouchers.js
+++ b/src/services/vouchers.js
@@ -17,8 +17,9 @@ export async function redeemVoucher(code, refreshStats) {
   const { data, error } = await supabase.functions.invoke('voucher-redeem', { body: { code } });
   if (error) return false;
   const success = data?.success ?? false;
-  if (success && typeof refreshStats === 'function') {
-    await refreshStats(true);
+  if (success) {
+    // Loyalty values change after redemption; bypass any cached stats
+    await refreshStats?.(true);
   }
   return success;
 }


### PR DESCRIPTION
## Summary
- remove cached stats so every refresh pulls latest loyalty values
- force stats refresh on cart screen mount and after voucher redemption

## Testing
- `npm test`
- manual consecutive redemption simulation

------
https://chatgpt.com/codex/tasks/task_e_68b53d335da88322a18dd881ea2ea34a