### PR TITLE
feat: include source in receipts

### DIFF
--- a/__tests__/orders.test.ts
+++ b/__tests__/orders.test.ts
@@ -1,5 +1,8 @@
-import test from 'node:test';
+import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { buildOrderRow, normalizeSource } from '../src/services/order-row.js';
 
 test('buildOrderRow includes pickup_code and preserves normalized source_meta', () => {
@@ -17,4 +20,33 @@ test('buildOrderRow includes pickup_code and preserves normalized source_meta', 
   assert.equal(row.pickup_code, '54321');
   assert.equal(row.source, 'app');
   assert.equal(row.source_meta, 'legacy-web');
+});
+
+test('saveReceiptForUser logs source app', async () => {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const libDir = resolve(dir, '../src/lib');
+  mkdirSync(libDir, { recursive: true });
+  writeFileSync(
+    resolve(libDir, 'supabase.js'),
+    "export const supabase = { from: () => ({ insert: () => ({ select: () => ({ single: async () => ({ data: { id: 'o1' }, error: null }) }) }) }) };"
+  );
+  const { saveReceiptForUser } = await import('../src/services/orders.js');
+
+  const log = mock.method(console, 'log');
+  await saveReceiptForUser('u1', {
+    orderId: 'o1',
+    pickupCode: '12345',
+    createdAt: '2024-01-01',
+    channel: 'click_and_collect',
+    source: 'app',
+    paymentMethod: 'test',
+    timeSlot: { startISO: '', endISO: '' },
+    items: [],
+    totals: { currency: 'GBP', subtotal: 0, discounts: 0, pifContribution: 0, tax: 0, grandTotal: 0 },
+  } as any);
+
+  const call = log.mock.calls.find((c) => c.arguments[0] === '[ORDERS] normalizeSource');
+  assert.equal(call?.arguments[1], 'app');
+  assert.equal(call?.arguments[3], 'app');
+  log.mock.restore();
 });

--- a/__tests__/receipt.test.ts
+++ b/__tests__/receipt.test.ts
@@ -59,3 +59,11 @@ test('currency rounds to 2dp', () => {
   assert.equal(receipt.items[0].unitFinalPrice, 1.34);
   assert.equal(receipt.totals.subtotal, 1.34);
 });
+
+test('buildReceipt sets source to app', () => {
+  const receipt = buildReceipt({
+    cartItems: [],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+  });
+  assert.equal(receipt.source, 'app');
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grant-rewards": "node scripts/grant-rewards.js",
     "reset-rewards": "node scripts/reset-rewards.js",
     "sync-menu-items": "node scripts/sync-menu-items.js",
-    "test": "tsc __tests__/receipt.test.ts __tests__/loyalty.test.ts __tests__/orders.test.ts src/utils/receipt.ts src/utils/loyalty.ts src/services/order-row.ts --module node16 --target ES2020 --outDir build && node --test build/__tests__/receipt.test.js build/__tests__/loyalty.test.js build/__tests__/orders.test.js"
+    "test": "tsc __tests__/receipt.test.ts __tests__/loyalty.test.ts __tests__/orders.test.ts src/utils/receipt.ts src/utils/loyalty.ts src/services/order-row.ts src/services/orders.ts --module node16 --target ES2020 --outDir build && node --test build/__tests__/receipt.test.js build/__tests__/loyalty.test.js build/__tests__/orders.test.js"
   },
   "dependencies": {
     "@expo-google-fonts/fraunces": "^0.4.0",

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -1,6 +1,6 @@
-import { supabase } from '../lib/supabase';
-import type { Receipt } from '../utils/receipt';
-import { buildOrderRow, normalizeSource } from './order-row';
+import { supabase } from '../lib/supabase.js';
+import type { Receipt } from '../utils/receipt.js';
+import { buildOrderRow, normalizeSource } from './order-row.js';
 
 
 export async function saveReceiptForUser(userId: string, receipt: Receipt, freeDrinksRedeemed = 0) {

--- a/src/utils/receipt.ts
+++ b/src/utils/receipt.ts
@@ -33,6 +33,7 @@ export type Receipt = {
   pickupCode: string;
   createdAt: string;
   channel: 'click_and_collect';
+  source?: 'app' | 'pos' | 'portal';
   paymentMethod: 'apple_pay' | 'card' | 'cash' | 'test';
   customer?: { id?: string; email?: string };
   timeSlot: { startISO: string; endISO: string };
@@ -142,6 +143,7 @@ export function buildReceipt({
     pickupCode,
     createdAt,
     channel: 'click_and_collect',
+    source: 'app',
     paymentMethod,
     customer: customer || undefined,
     timeSlot: {


### PR DESCRIPTION
## Summary
- add `source: 'app'` to receipts so origin persists
- test logging of source during order saves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b53d2f93d083228d0f3d69e6b2650e