### PR TITLE
Preserve stats on refresh failure

### DIFF
--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -52,12 +52,12 @@ export function StatsProvider({ children }) {
         console.log('loyalty stamps and free drinks have been received');
         return s;
       } catch {
-        const fallback = { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+        const fallback = globalThis.preloaded?.stats || stats;
         applyStats(fallback);
         return fallback;
       }
     },
-    [applyStats],
+    [applyStats, stats],
   );
 
   const value = useMemo(


### PR DESCRIPTION
## Summary
- keep previous stats when refresh fails to avoid clearing loyalty data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54051c6a08322be6c7df3bf79fd4c