### PR TITLE
Use ref to preserve latest stats

### DIFF
--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useCallback, useMemo } from 'react';
+import React, { createContext, useState, useCallback, useMemo, useRef } from 'react';
 import { getMyStats } from '../services/stats';
 import { syncVouchers } from '../services/vouchers';
 import { applyStampAccrual } from '../utils/rewards';
@@ -17,8 +17,10 @@ export function StatsProvider({ children }) {
       vouchers: [],
     };
   const [stats, setStatsState] = useState(initial);
+  const statsRef = useRef(initial);
 
   const applyStats = useCallback((s) => {
+    statsRef.current = s;
     setStatsState(s);
     globalThis.freebiesLeft = s.freebiesLeft;
     globalThis.loyaltyStamps = s.loyaltyStamps;
@@ -26,39 +28,36 @@ export function StatsProvider({ children }) {
     globalThis.preloaded.stats = s;
   }, []);
 
-  const refreshStats = useCallback(
-    async () => {
-      try {
-        let s = await getMyStats();
-        const mismatch =
-          s.freebiesLeft !== (Array.isArray(s.vouchers) ? s.vouchers.length : 0);
-        const outOfRange = s.loyaltyStamps < 0 || s.loyaltyStamps > 7;
-        if (mismatch || outOfRange) {
-          await syncVouchers();
-          s = await getMyStats();
-        }
-        if (s.loyaltyStamps < 0 || s.loyaltyStamps > 7) {
-          const { vouchersEarned, stampsRemainder } = applyStampAccrual(
-            0,
-            s.loyaltyStamps,
-          );
-          s.loyaltyStamps = stampsRemainder;
-          if (vouchersEarned > 0) {
-            s.freebiesLeft += vouchersEarned;
-            s.vouchers = Array.isArray(s.vouchers) ? s.vouchers : [];
-          }
-        }
-        applyStats(s);
-        console.log('loyalty stamps and free drinks have been received');
-        return s;
-      } catch {
-        const fallback = globalThis.preloaded?.stats || stats;
-        applyStats(fallback);
-        return fallback;
+  const refreshStats = useCallback(async () => {
+    try {
+      let s = await getMyStats();
+      const mismatch =
+        s.freebiesLeft !== (Array.isArray(s.vouchers) ? s.vouchers.length : 0);
+      const outOfRange = s.loyaltyStamps < 0 || s.loyaltyStamps > 7;
+      if (mismatch || outOfRange) {
+        await syncVouchers();
+        s = await getMyStats();
       }
-    },
-    [applyStats, stats],
-  );
+      if (s.loyaltyStamps < 0 || s.loyaltyStamps > 7) {
+        const { vouchersEarned, stampsRemainder } = applyStampAccrual(
+          0,
+          s.loyaltyStamps,
+        );
+        s.loyaltyStamps = stampsRemainder;
+        if (vouchersEarned > 0) {
+          s.freebiesLeft += vouchersEarned;
+          s.vouchers = Array.isArray(s.vouchers) ? s.vouchers : [];
+        }
+      }
+      applyStats(s);
+      console.log('loyalty stamps and free drinks have been received');
+      return s;
+    } catch {
+      const fallback = globalThis.preloaded?.stats || statsRef.current;
+      applyStats(fallback);
+      return fallback;
+    }
+  }, [applyStats]);
 
   const value = useMemo(
     () => ({ stats, refreshStats, setStats: applyStats }),


### PR DESCRIPTION
## Summary
- track latest stats in a `useRef`
- store updates in the ref alongside state
- read from the ref in `refreshStats` so the callback only depends on `applyStats`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54241ccb48322bc8510566165149b