### PR TITLE
replace console-driven loading signals with events

### DIFF
--- a/src/boot/loadingSignals.ts
+++ b/src/boot/loadingSignals.ts
@@ -6,36 +6,6 @@ type Listener = (state: Record<Keys, boolean>) => void;
 const state: Record<Keys, boolean> = { auth: false, stamps: false, cms: false };
 const listeners = new Set<Listener>();
 
-// Keep original console.log
-const originalLog = console.log;
-
-// Wrap console.log once; detect exact phrases (case-insensitive contains)
-let patched = false;
-export function patchConsoleForLoadingSignals() {
-  if (patched) return;
-  patched = true;
-  console.log = (...args: any[]) => {
-    try {
-      const msg = args.map(String).join(' ');
-      const lower = msg.toLowerCase();
-
-      if (lower.includes('user is signed in')) {
-
-        state.auth = true; scheduleNotify();
-      }
-      if (lower.includes('loyalty stamps and free drinks have been received')) {
-        state.stamps = true; scheduleNotify();
-      }
-      if (lower.includes('cms info has all been received')) {
-        state.cms = true; scheduleNotify();
-
-      }
-    } catch {}
-    // always forward to original log
-    originalLog(...args);
-  };
-}
-
 export function subscribe(fn: Listener) {
   listeners.add(fn);
   const t = setTimeout(() => {
@@ -70,14 +40,12 @@ function scheduleNotify() {
   }, 0);
 }
 
-// Optional: for manual marking from code instead of console text
+// Mark a loader as complete. Idempotent.
 export function markLoaded(key: Keys) {
-
   if (!state[key]) {
     state[key] = true;
     scheduleNotify();
   }
-
 }
 
 // Expose read-only

--- a/src/components/SplashGate.tsx
+++ b/src/components/SplashGate.tsx
@@ -1,16 +1,11 @@
 import React, { useEffect, useState, useRef } from 'react';
 
-import { Image, StyleSheet, Animated } from 'react-native';
+import { Image, StyleSheet, Animated, InteractionManager } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { palette } from '../design/theme';
 import logo from '../../assets/logo.png';
-import {
-  patchConsoleForLoadingSignals,
-  subscribe,
-  getLoadingState,
-  markLoaded,
-} from '../boot/loadingSignals';
+import { subscribe, getLoadingState, markLoaded } from '../boot/loadingSignals';
 
 import { preloadMenuItems } from '../boot/preload';
 
@@ -38,15 +33,14 @@ export default function SplashGate() {
 
 
   useEffect(() => {
-    patchConsoleForLoadingSignals();
-
-
     preloadMenuItems().finally(() => markLoaded('cms'));
 
     const unsub = subscribe((st) => {
       if (st.auth && st.stamps && st.cms) {
-        Animated.timing(gateOpacity, { toValue: 0, duration: FADE_MS, useNativeDriver: true })
-          .start(() => setVisible(false));
+        InteractionManager.runAfterInteractions(() => {
+          Animated.timing(gateOpacity, { toValue: 0, duration: FADE_MS, useNativeDriver: true })
+            .start(() => setVisible(false));
+        });
       }
     });
 
@@ -65,10 +59,12 @@ export default function SplashGate() {
 
     // If all are already ready (e.g. dev reload), hide immediately
     const s = getLoadingState();
-    if (s.auth && s.stamps && s.cms) setTimeout(() => {
-      Animated.timing(gateOpacity, { toValue: 0, duration: FADE_MS, useNativeDriver: true })
-        .start(() => setVisible(false));
-    }, 0);
+    if (s.auth && s.stamps && s.cms) {
+      InteractionManager.runAfterInteractions(() => {
+        Animated.timing(gateOpacity, { toValue: 0, duration: FADE_MS, useNativeDriver: true })
+          .start(() => setVisible(false));
+      });
+    }
 
     return () => {
       unsub?.();

--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -2,6 +2,7 @@ import React, { createContext, useState, useCallback, useMemo, useRef } from 're
 import { getMyStats } from '../services/stats';
 import { syncVouchers } from '../services/vouchers';
 import { applyStampAccrual } from '../utils/rewards';
+import { markLoaded } from '../boot/loadingSignals';
 
 export const StatsContext = createContext({
   stats: { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] },
@@ -50,11 +51,12 @@ export function StatsProvider({ children }) {
         }
       }
       applyStats(s);
-      console.log('loyalty stamps and free drinks have been received');
+      markLoaded('stamps');
       return s;
     } catch {
       const fallback = globalThis.preloaded?.stats || statsRef.current;
       applyStats(fallback);
+      markLoaded('stamps');
       return fallback;
     }
   }, [applyStats]);

--- a/src/services/cms.js
+++ b/src/services/cms.js
@@ -1,4 +1,5 @@
 import Constants from 'expo-constants';
+import { markLoaded } from '../boot/loadingSignals';
 
 const extra = (Constants?.expoConfig?.extra) || (Constants?.manifest?.extra) || {};
 const FUNCTIONS_URL = extra.CMS_FUNCTIONS_URL || "https://eamewialuovzguldcdcf.functions.supabase.co";
@@ -18,9 +19,10 @@ export async function getCMS(force = false) {
     cached = data;
     globalThis.preloaded = globalThis.preloaded || {};
     globalThis.preloaded.cms = data;
-    console.log('CMS info has all been received');
+    markLoaded('cms');
     return data;
   } catch {
+    markLoaded('cms');
     return cached || {};
   }
 }

--- a/src/services/membership.js
+++ b/src/services/membership.js
@@ -1,17 +1,20 @@
 import { supabase, hasSupabase } from '../lib/supabase';
+import { markLoaded } from '../boot/loadingSignals';
 
 export async function getMembershipSummary() {
   if (!hasSupabase || !supabase) {
+    markLoaded('auth');
     return { signedIn: false, tier: 'free', status: 'none', next_billing_at: null };
   }
 
   try {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session || !session.user) {
+      markLoaded('auth');
       return { signedIn: false, tier: 'free', status: 'none', next_billing_at: null };
     }
 
-    console.log('user is signed in');
+    markLoaded('auth');
 
     const meta = session.user.user_metadata || {};
     // For testing, force specific user email to be treated as paid tier
@@ -31,6 +34,7 @@ export async function getMembershipSummary() {
       next_billing_at: null,
     };
   } catch {
+    markLoaded('auth');
     return { signedIn: false, tier: 'free', status: 'none', next_billing_at: null };
   }
 }


### PR DESCRIPTION
## Summary
- drop console.log patch in favour of explicit loader state API
- signal auth, stats, and CMS completion through markLoaded helpers
- fade SplashGate only after React commits via InteractionManager

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b55475bf448322afd3e117d05c9198