### PR TITLE
Handle loyalty stamp sync on auth state changes

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import 'react-native-gesture-handler';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { StatusBar, ImageBackground } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -10,24 +10,9 @@ import Router from './src/navigation/Router';
 import { useFonts, Fraunces_600SemiBold, Fraunces_700Bold } from '@expo-google-fonts/fraunces';
 import appBgBase64 from './assets/appBgBase64';
 import SplashGate from './src/components/SplashGate';
-import { supabase } from './src/lib/supabase';
-import { getMyStats } from './src/services/stats';
 
 export default function App() {
   const [loaded] = useFonts({ Fraunces_600SemiBold, Fraunces_700Bold });
-  useEffect(() => {
-    supabase.auth.getSession().then(async ({ data }) => {
-      const uid = data?.session?.user?.id;
-      if (uid) {
-        try {
-          const { loyaltyStamps, freebiesLeft } = await getMyStats();
-          console.log(
-            `[LOYALTY] on boot → stamps: ${loyaltyStamps}, free drinks: ${freebiesLeft}`
-          );
-        } catch {}
-      }
-    });
-  }, []);
   if (!loaded)
     return (
       <GestureHandlerRootView style={{ flex: 1 }}>

--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -1,8 +1,9 @@
-import React, { createContext, useState, useCallback, useMemo, useRef } from 'react';
+import React, { createContext, useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { getMyStats } from '../services/stats';
 import { syncVouchers } from '../services/vouchers';
 import { applyStampAccrual } from '../utils/rewards';
 import { markLoaded } from '../boot/loadingSignals';
+import { supabase } from '../lib/supabase';
 
 export const StatsContext = createContext({
   stats: { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] },
@@ -60,6 +61,25 @@ export function StatsProvider({ children }) {
       return fallback;
     }
   }, [applyStats]);
+
+  useEffect(() => {
+    if (!supabase?.auth) return;
+    const zero = { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+    const sub = supabase.auth.onAuthStateChange(async (event, session) => {
+      if (!session?.user) {
+        applyStats(zero);
+        console.log('[LOYALTY] reset → stamps: 0, free drinks: 0');
+        return;
+      }
+      applyStats(zero);
+      try {
+        const s = await refreshStats();
+        const tag = event === 'INITIAL_SESSION' ? 'on boot' : 'auth';
+        console.log(`[LOYALTY] ${tag} → stamps: ${s.loyaltyStamps}, free drinks: ${s.freebiesLeft}`);
+      } catch {}
+    });
+    return () => { try { sub?.data?.subscription?.unsubscribe?.(); } catch {} };
+  }, [applyStats, refreshStats]);
 
   const value = useMemo(
     () => ({ stats, refreshStats, setStats: applyStats }),


### PR DESCRIPTION
## Summary
- Reset local loyalty stats to zero whenever auth state changes
- Fetch stamps from server on login and on boot, logging the unified totals
- Drop boot-time stats fetch from App.js so StatsProvider is the single source of truth

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5579f12188322b75631abee3c402d