### PR TITLE
Ensure CMS loader marks loaded on failed fetch

### DIFF
--- a/src/services/cms.js
+++ b/src/services/cms.js
@@ -14,7 +14,10 @@ export async function getCMS(force = false) {
       method: 'GET',
       headers: CMS_ANON ? { Authorization: `Bearer ${CMS_ANON}` } : {}
     });
-    if (!res.ok) return cached || {};
+    if (!res.ok) {
+      markLoaded('cms');
+      return cached || {};
+    }
     const data = await res.json();
     cached = data;
     globalThis.preloaded = globalThis.preloaded || {};


### PR DESCRIPTION
## Summary
- mark CMS loading signal even when `/cms-get` responds with an error

## Testing
- `npm test`
- `node --loader ./loader.mjs temp-cms-test.mjs` (mocked 500 response shows `{ cms: true }`)


------
https://chatgpt.com/codex/tasks/task_e_68b557b525e48322899a1f32c4b89596