### PR TITLE
fix: persist free drink redemption

### DIFF
--- a/src/components/FreeDrinksCounter.js
+++ b/src/components/FreeDrinksCounter.js
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import Svg, { Circle } from 'react-native-svg';
 import { palette } from '../design/theme';
+import { StatsContext } from '../context/StatsContext';
 
-export default function FreeDrinksCounter({ count = 0 }) {
+export default function FreeDrinksCounter() {
+  const { stats } = useContext(StatsContext);
+  const count = Math.max(0, Number(stats?.freebiesLeft || 0));
   const limit = 3;
   const ratio = Math.max(0, Math.min(1, count / limit));
   const size = 64;

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -327,9 +327,13 @@ export default function CartScreen({ navigation }) {
                   } catch {
                     vouchers = stats?.vouchers || [];
                   }
+                  const freebiesLeft = Math.max(
+                    0,
+                    (data?.free_drinks ?? freeDrinks) - redeemCount,
+                  );
                   setStats({
                     loyaltyStamps: data?.loyalty_stamps ?? 0,
-                    freebiesLeft: data?.free_drinks ?? 0,
+                    freebiesLeft,
                     vouchers,
                   });
                   if (__DEV__) {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -138,7 +138,7 @@ export default function HomeScreen({ navigation }) {
 
             {(member?.tier === 'paid' || stats.freebiesLeft > 0) && (
                 <View style={{ marginTop: 16 }}>
-                  <FreeDrinksCounter count={stats.freebiesLeft} />
+                  <FreeDrinksCounter />
                 </View>
               )}
             </View>

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -224,7 +224,7 @@ export default function MembershipScreen({ navigation }) {
 
             {(summary.tier === 'paid' || (stats?.freebiesLeft ?? 0) > 0) && (
               <View style={{ marginTop: 14 }}>
-                <FreeDrinksCounter count={stats?.freebiesLeft ?? 0} />
+                <FreeDrinksCounter />
               </View>
             )}
 


### PR DESCRIPTION
## Summary
- decrease freebies count in loyalty store when a free drink is redeemed
- derive free drink counter from shared stats store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5578dbf2083228d607b198d9fba7a