### PR TITLE
Use single result for checkout loyalty RPC

### DIFF
--- a/__tests__/loyalty.test.ts
+++ b/__tests__/loyalty.test.ts
@@ -99,11 +99,16 @@ test('checkoutLoyalty caps stamps at 7 and increments free drinks', async () => 
     `export const hasSupabase = true;
 const state = { stamps: 0, free: 0 };
 export const supabase = {
-  rpc: async (_fn, { p_add_stamps }) => {
+  rpc: (_fn, { p_add_stamps }) => {
     const total = state.stamps + p_add_stamps;
     state.free += Math.floor(total / 8);
     state.stamps = total % 8;
-    return { data: { loyalty_stamps: state.stamps, free_drinks: state.free }, error: null };
+    return {
+      single: async () => ({
+        data: { loyalty_stamps: state.stamps, free_drinks: state.free },
+        error: null,
+      }),
+    };
   },
 };`
   );
@@ -112,12 +117,12 @@ export const supabase = {
   copyFileSync(resolve(dir, '../../src/services/loyalty.js'), resolve(svcDir, 'loyalty.js'));
   const { checkoutLoyalty } = await import('../src/services/loyalty.js');
   const log = mock.method(console, 'log');
-  let res = await checkoutLoyalty('u1', 'o1', 5, 0);
-  assert.equal(res.data?.loyalty_stamps, 5);
-  assert.equal(res.data?.free_drinks, 0);
-  res = await checkoutLoyalty('u1', 'o2', 4, 0);
-  assert.equal(res.data?.loyalty_stamps, 1);
-  assert.equal(res.data?.free_drinks, 1);
+    let { data } = await checkoutLoyalty('u1', 'o1', 5, 0);
+    assert.equal(data?.loyalty_stamps, 5);
+    assert.equal(data?.free_drinks, 0);
+    ({ data } = await checkoutLoyalty('u1', 'o2', 4, 0));
+    assert.equal(data?.loyalty_stamps, 1);
+    assert.equal(data?.free_drinks, 1);
   assert.ok(
     log.mock.calls.some((c) => String(c.arguments[0]).includes('new free drinks: 1'))
   );

--- a/src/services/loyalty.js
+++ b/src/services/loyalty.js
@@ -14,19 +14,21 @@ export async function redeemLoyaltyReward() {
 export async function checkoutLoyalty(p_user, p_order_id, p_add_stamps, p_redeem) {
   if (!hasSupabase || !supabase) return { data: null, error: new Error('no supabase') };
   try {
-    const res = await supabase.rpc('checkout_loyalty', {
-      p_user,
-      p_order_id,
-      p_add_stamps,
-      p_redeem,
-    });
-    if (res.data) {
+    const { data, error } = await supabase
+      .rpc('checkout_loyalty', {
+        p_user,
+        p_order_id,
+        p_add_stamps,
+        p_redeem,
+      })
+      .single();
+    if (data) {
       console.log(
-        `[LOYALTY] awarding: +${p_add_stamps} stamp(s); new free drinks: ${res.data.free_drinks}; loyalty stamps: ${res.data.loyalty_stamps}`
+        `[LOYALTY] awarding: +${p_add_stamps} stamp(s); new free drinks: ${data.free_drinks}; loyalty stamps: ${data.loyalty_stamps}`
       );
-      console.assert(res.data.loyalty_stamps <= 7, 'loyalty_stamps exceeded 7');
+      console.assert(data.loyalty_stamps <= 7, 'loyalty_stamps exceeded 7');
     }
-    return res;
+    return { data, error };
   } catch (error) {
     return { data: null, error };
   }


### PR DESCRIPTION
## Summary
- call `checkout_loyalty` RPC with `.single()` so callers get a single object
- keep CartScreen and other callers destructuring `{ data, error }`
- adjust loyalty tests to mock `.single()` and destructure returned data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b55a7bb2b083229865604f9fa0545c