### PR TITLE
Count specials as drinks for loyalty stamps

### DIFF
--- a/__tests__/loyalty.test.ts
+++ b/__tests__/loyalty.test.ts
@@ -90,7 +90,7 @@ test('awardStamps rollover with idempotency', () => {
   assert.deepEqual(profile, { stamps: 2, freebies: 1 });
 });
 
-test('checkoutLoyalty caps stamps at 7 and increments free drinks', async () => {
+test('checkoutLoyalty caps stamps at 7 and increments free drinks', { concurrency: false }, async () => {
   const dir = dirname(fileURLToPath(import.meta.url));
   const libDir = resolve(dir, '../src/lib');
   mkdirSync(libDir, { recursive: true });
@@ -127,4 +127,26 @@ export const supabase = {
     log.mock.calls.some((c) => String(c.arguments[0]).includes('new free drinks: 1'))
   );
   log.mock.restore();
+});
+
+test('specials items are treated as drinks and award stamps', { concurrency: false }, async () => {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const libDir = resolve(dir, '../src/lib');
+  mkdirSync(libDir, { recursive: true });
+  writeFileSync(
+    resolve(libDir, 'supabase.js'),
+    'export const hasSupabase = true; export const supabase = {};',
+  );
+  // @ts-ignore
+  const { isDrinkItem } = await import('../../src/utils/isDrinkItem.js');
+  const items = [
+    { id: 'specials:pumpkin-latte', quantity: 1, category: 'specials' },
+  ];
+  const drinkCount = items
+    .filter(isDrinkItem)
+    .reduce((sum, it) => sum + (it.quantity || 0), 0);
+  assert.equal(drinkCount, 1);
+  const redeemCount = 0;
+  const stampsToAward = Math.max(0, drinkCount - redeemCount);
+  assert.ok(stampsToAward > 0);
 });

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -15,6 +15,7 @@ import { getMembershipSummary } from '../services/membership';
 import { getToday } from '../services/homeData';
 import { checkoutLoyalty } from '../services/loyalty';
 import { syncVouchers } from '../services/vouchers';
+import { isDrinkItem } from '../utils/isDrinkItem';
 
 export default function CartScreen({ navigation }) {
   const insets = useSafeAreaInsets();
@@ -49,14 +50,6 @@ export default function CartScreen({ navigation }) {
     clearItem, // some apps name it like this
     clear,
   } = cart;
-  const isDrinkItem = (item) => {
-    const key = (item?.cms_key || item?.id || '').toLowerCase();
-    if (key.includes('.drink')) return true;
-    const category = (item?.category || '').toLowerCase();
-    if (category === 'coffee') return true;
-    if (key.startsWith('coffee:')) return true;
-    return false;
-  };
 
   const drinkCount = useMemo(
     () => items.filter(isDrinkItem).reduce((sum, it) => sum + (it.quantity || 0), 0),

--- a/src/utils/isDrinkItem.js
+++ b/src/utils/isDrinkItem.js
@@ -1,0 +1,11 @@
+export const isDrinkItem = (item) => {
+  const key = (item?.cms_key || item?.id || '').toLowerCase();
+  if (key.includes('.drink')) return true;
+  const category = (item?.category || '').toLowerCase();
+  if (category === 'coffee') return true;
+  if (key.startsWith('coffee:')) return true;
+  if (key.startsWith('specials:')) return true;
+  if (category === 'specials') return true;
+  if (item?.drink || item?.metadata?.drink) return true;
+  return false;
+};


### PR DESCRIPTION
## Summary
- treat seasonal/specials items as drink items for stamp calculation
- pull `isDrinkItem` into shared util and use in cart drink counting
- test that specials items add positive stamp counts at checkout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b55cf9e2188322b55fe56acd34b81a