### PR TITLE
Emit row from checkout_loyalty

### DIFF
--- a/supabase/migrations/0015_fix_loyalty_tx.sql
+++ b/supabase/migrations/0015_fix_loyalty_tx.sql
@@ -130,7 +130,7 @@ BEGIN
 
   loyalty_stamps := COALESCE(cur_stamps,0);
   free_drinks := COALESCE(cur_free,0);
-  RETURN;
+  RETURN QUERY SELECT loyalty_stamps, free_drinks;
 END;
 $$;
 


### PR DESCRIPTION
## Summary
- ensure checkout_loyalty returns a row even when no ledger record is inserted

## Testing
- `npm test` *(fails: supabase.from is not a function)*
- `npx supabase db push` *(fails: Cannot find project ref. Have you run supabase link?)*

------
https://chatgpt.com/codex/tasks/task_e_68b56144bcf483228a1b6d3985afca22