### PR TITLE
Handle missing loyalty rows

### DIFF
--- a/__tests__/loyalty.test.ts
+++ b/__tests__/loyalty.test.ts
@@ -104,7 +104,7 @@ export const supabase = {
     state.free += Math.floor(total / 8);
     state.stamps = total % 8;
     return {
-      single: async () => ({
+      maybeSingle: async () => ({
         data: { loyalty_stamps: state.stamps, free_drinks: state.free },
         error: null,
       }),

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -310,6 +310,7 @@ export default function CartScreen({ navigation }) {
                   stampsToAward,
                   redeemCount,
                 );
+                const loyalty = data ?? { loyalty_stamps: 0, free_drinks: 0 };
 
                 if (error) {
                   console.warn('[LOYALTY] checkout_loyalty failed:', error);
@@ -322,10 +323,10 @@ export default function CartScreen({ navigation }) {
                   }
                   const freebiesLeft = Math.max(
                     0,
-                    (data?.free_drinks ?? freeDrinks) - redeemCount,
+                    loyalty.free_drinks - redeemCount,
                   );
                   setStats({
-                    loyaltyStamps: data?.loyalty_stamps ?? 0,
+                    loyaltyStamps: loyalty.loyalty_stamps,
                     freebiesLeft,
                     vouchers,
                   });

--- a/src/services/loyalty.js
+++ b/src/services/loyalty.js
@@ -14,15 +14,16 @@ export async function redeemLoyaltyReward() {
 export async function checkoutLoyalty(p_user, p_order_id, p_add_stamps, p_redeem) {
   if (!hasSupabase || !supabase) return { data: null, error: new Error('no supabase') };
   try {
-    const { data, error } = await supabase
+    const { data: rawData, error } = await supabase
       .rpc('checkout_loyalty', {
         p_user,
         p_order_id,
         p_add_stamps,
         p_redeem,
       })
-      .single();
-    if (data) {
+      .maybeSingle();
+    const data = rawData ?? { loyalty_stamps: 0, free_drinks: 0 };
+    if (!error) {
       console.log(
         `[LOYALTY] awarding: +${p_add_stamps} stamp(s); new free drinks: ${data.free_drinks}; loyalty stamps: ${data.loyalty_stamps}`
       );


### PR DESCRIPTION
## Summary
- switch checkoutLoyalty to `.maybeSingle()` and default to zero stamps/freebies when no profile row exists
- ensure CartScreen copes with missing loyalty data without logging an error
- update loyalty tests for `.maybeSingle()`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5614a22348322855f3f82f8a33602