### PR TITLE
Use voucher count for free drink tracking

### DIFF
--- a/src/components/FreeDrinksCounter.js
+++ b/src/components/FreeDrinksCounter.js
@@ -7,7 +7,7 @@ import { StatsContext } from '../context/StatsContext';
 
 export default function FreeDrinksCounter() {
   const { stats } = useContext(StatsContext);
-  const count = Math.max(0, Number(stats?.freebiesLeft || 0));
+  const count = Math.max(0, Number(stats?.vouchers?.length || 0));
   const limit = 3;
   const ratio = Math.max(0, Math.min(1, count / limit));
   const size = 64;

--- a/src/components/membership/MembershipSignedInPanel.js
+++ b/src/components/membership/MembershipSignedInPanel.js
@@ -56,8 +56,14 @@ export default function MembershipSignedInPanel({ summary, stats, user }) {
 
       {isPaid && (
         <View style={styles.gridRow}>
-          <Stat label="Free drinks left" value={stats.freebiesLeft} />
-          <Stat label="Dividends pending" value={formatCurrency(Number(stats.dividendsPending))} />
+          <Stat
+            label="Free drinks left"
+            value={stats.vouchers?.length ?? 0}
+          />
+          <Stat
+            label="Dividends pending"
+            value={formatCurrency(Number(stats.dividendsPending))}
+          />
         </View>
       )}
       <View style={styles.gridRow}>

--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -6,37 +6,46 @@ import { markLoaded } from '../boot/loadingSignals';
 import { supabase } from '../lib/supabase';
 
 export const StatsContext = createContext({
-  stats: { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] },
-  refreshStats: async () => ({ loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] }),
+  stats: { loyaltyStamps: 0, vouchers: [], freebiesLeft: 0 },
+  refreshStats: async () => ({ loyaltyStamps: 0, vouchers: [], freebiesLeft: 0 }),
   setStats: () => {},
 });
 
 export function StatsProvider({ children }) {
-  const initial =
-    globalThis.preloaded?.stats || {
-      loyaltyStamps: 0,
-      freebiesLeft: 0,
-      vouchers: [],
-    };
+  const initialRaw = globalThis.preloaded?.stats || {
+    loyaltyStamps: 0,
+    vouchers: [],
+  };
+  const initial = {
+    loyaltyStamps: Number(initialRaw.loyaltyStamps) || 0,
+    vouchers: Array.isArray(initialRaw.vouchers)
+      ? initialRaw.vouchers.filter(Boolean)
+      : [],
+  };
+  initial.freebiesLeft = initial.vouchers.length;
   const [stats, setStatsState] = useState(initial);
   const statsRef = useRef(initial);
 
   const applyStats = useCallback((s) => {
-    statsRef.current = s;
-    setStatsState(s);
-    globalThis.freebiesLeft = s.freebiesLeft;
-    globalThis.loyaltyStamps = s.loyaltyStamps;
+    const vouchers = Array.isArray(s.vouchers) ? s.vouchers.filter(Boolean) : [];
+    const next = {
+      loyaltyStamps: Number(s.loyaltyStamps) || 0,
+      vouchers,
+      freebiesLeft: vouchers.length,
+    };
+    statsRef.current = next;
+    setStatsState(next);
+    globalThis.freebiesLeft = next.freebiesLeft;
+    globalThis.loyaltyStamps = next.loyaltyStamps;
     globalThis.preloaded = globalThis.preloaded || {};
-    globalThis.preloaded.stats = s;
+    globalThis.preloaded.stats = next;
   }, []);
 
   const refreshStats = useCallback(async () => {
     try {
       let s = await getMyStats();
-      const mismatch =
-        s.freebiesLeft !== (Array.isArray(s.vouchers) ? s.vouchers.length : 0);
       const outOfRange = s.loyaltyStamps < 0 || s.loyaltyStamps > 7;
-      if (mismatch || outOfRange) {
+      if (outOfRange) {
         await syncVouchers();
         s = await getMyStats();
       }
@@ -47,13 +56,16 @@ export function StatsProvider({ children }) {
         );
         s.loyaltyStamps = stampsRemainder;
         if (vouchersEarned > 0) {
-          s.freebiesLeft += vouchersEarned;
           s.vouchers = Array.isArray(s.vouchers) ? s.vouchers : [];
         }
       }
-      applyStats(s);
+      const decorated = {
+        ...s,
+        freebiesLeft: Array.isArray(s.vouchers) ? s.vouchers.length : 0,
+      };
+      applyStats(decorated);
       markLoaded('stamps');
-      return s;
+      return decorated;
     } catch {
       const fallback = globalThis.preloaded?.stats || statsRef.current;
       applyStats(fallback);
@@ -64,7 +76,7 @@ export function StatsProvider({ children }) {
 
   useEffect(() => {
     if (!supabase?.auth) return;
-    const zero = { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+    const zero = { loyaltyStamps: 0, vouchers: [] };
     const sub = supabase.auth.onAuthStateChange(async (event, session) => {
       if (!session?.user) {
         applyStats(zero);
@@ -75,7 +87,9 @@ export function StatsProvider({ children }) {
       try {
         const s = await refreshStats();
         const tag = event === 'INITIAL_SESSION' ? 'on boot' : 'auth';
-        console.log(`[LOYALTY] ${tag} → stamps: ${s.loyaltyStamps}, free drinks: ${s.freebiesLeft}`);
+        console.log(
+          `[LOYALTY] ${tag} → stamps: ${s.loyaltyStamps}, free drinks: ${s.freebiesLeft}`,
+        );
       } catch {}
     });
     return () => { try { sub?.data?.subscription?.unsubscribe?.(); } catch {} };

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -19,13 +19,13 @@ import { isDrinkItem } from '../utils/isDrinkItem';
 
 export default function CartScreen({ navigation }) {
   const insets = useSafeAreaInsets();
-  const { stats = { freebiesLeft: 0 }, refreshStats, setStats } =
+  const { stats = { vouchers: [] }, refreshStats, setStats } =
     useContext(StatsContext) || {
-      stats: { freebiesLeft: 0 },
+      stats: { vouchers: [] },
       refreshStats: async () => {},
       setStats: () => {},
     };
-  const freeDrinks = stats?.freebiesLeft ?? 0;
+  const freeDrinks = stats?.vouchers?.length ?? 0;
   const { setHasOrders, refreshOrdersPresence } = useOrdersPresence();
 
   const showToast = (msg) => {
@@ -321,13 +321,8 @@ export default function CartScreen({ navigation }) {
                   } catch {
                     vouchers = stats?.vouchers || [];
                   }
-                  const freebiesLeft = Math.max(
-                    0,
-                    loyalty.free_drinks - redeemCount,
-                  );
                   setStats({
                     loyaltyStamps: loyalty.loyalty_stamps,
-                    freebiesLeft,
                     vouchers,
                   });
                   if (__DEV__) {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -136,7 +136,7 @@ export default function HomeScreen({ navigation }) {
               <LoyaltyStampTile count={stats.loyaltyStamps} />
             </View>
 
-            {(member?.tier === 'paid' || stats.freebiesLeft > 0) && (
+            {(member?.tier === 'paid' || (stats.vouchers?.length ?? 0) > 0) && (
                 <View style={{ marginTop: 16 }}>
                   <FreeDrinksCounter />
                 </View>

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -44,18 +44,16 @@ export default function MembershipScreen({ navigation }) {
   const [refreshing, setRefreshing] = useState(false);
 
   const vouchers = React.useMemo(() => {
-    if (Array.isArray(stats?.vouchers) && stats.vouchers.length) {
-      return stats.vouchers.map(code => ({ id: code, code, used: false, expiresAt: null }));
+    if (Array.isArray(stats?.vouchers)) {
+      return stats.vouchers.map((code) => ({
+        id: code,
+        code,
+        used: false,
+        expiresAt: null,
+      }));
     }
-    const n = Math.max(0, Number(stats?.freebiesLeft || 0));
-    return Array.from({ length: n }, (_, i) => ({
-      id: `local-${i}`,
-      code: `FREE-${i + 1}`,
-      used: false,
-      expiresAt: null,
-      isLocal: true,
-    }));
-  }, [vouchersKey, stats?.freebiesLeft]);
+    return [];
+  }, [vouchersKey]);
 
   const isExpired = React.useCallback((iso) => {
     if (!iso) return false;
@@ -135,7 +133,7 @@ export default function MembershipScreen({ navigation }) {
 
   useEffect(() => {
     const prev = prevFreebies.current;
-    const curr = stats?.freebiesLeft ?? 0;
+    const curr = stats?.vouchers?.length ?? 0;
     if (curr - prev === 1) {
       Alert.alert('Free drink earned', 'A free drink voucher has been added to your account.');
       setNotice("You've earned a free drink!");
@@ -145,7 +143,7 @@ export default function MembershipScreen({ navigation }) {
     }
     prevFreebies.current = curr;
     if (curr === 0) setNotice('');
-  }, [stats?.freebiesLeft]);
+  }, [stats?.vouchers?.length]);
 
   const handleAddToWallet = useCallback(async () => {
     try {
@@ -163,7 +161,9 @@ export default function MembershipScreen({ navigation }) {
       <View style={[styles.header, { paddingTop: insets.top }]}><Text style={styles.headerTitle}>Membership</Text></View>
       <ScrollView refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />} contentContainerStyle={styles.content}>
         <Text style={styles.title}>Membership</Text>
-        {notice && (stats?.freebiesLeft ?? 0) > 0 ? <Text style={styles.notice}>{notice}</Text> : null}
+        {notice && (stats?.vouchers?.length ?? 0) > 0 ? (
+          <Text style={styles.notice}>{notice}</Text>
+        ) : null}
 
         {summary.signedIn ? (
           <>
@@ -222,7 +222,7 @@ export default function MembershipScreen({ navigation }) {
               )}
             </View>
 
-            {(summary.tier === 'paid' || (stats?.freebiesLeft ?? 0) > 0) && (
+            {(summary.tier === 'paid' || (stats?.vouchers?.length ?? 0) > 0) && (
               <View style={{ marginTop: 14 }}>
                 <FreeDrinksCounter />
               </View>

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -4,7 +4,7 @@ import { getFunctionsUrl } from '../lib/config';
 export async function getMyStats() {
   try {
     const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.access_token) return { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+    if (!session?.access_token) return { loyaltyStamps: 0, vouchers: [] };
 
     const base = getFunctionsUrl();
     const url = `${base.replace(/\/$/, '')}/me-stats`;
@@ -24,16 +24,15 @@ export async function getMyStats() {
 
     if (!res.ok) {
       console.error('me-stats error', res.status, json);
-      return { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+      return { loyaltyStamps: 0, vouchers: [] };
     }
 
     return {
       loyaltyStamps: Number(json?.loyaltyStamps ?? 0),
-      freebiesLeft: Number(json?.freebiesLeft ?? 0),
-      vouchers: Array.isArray(json?.vouchers) ? json.vouchers.filter(Boolean) : []
+      vouchers: Array.isArray(json?.vouchers) ? json.vouchers.filter(Boolean) : [],
     };
   } catch (e) {
     console.error('getMyStats failed', e);
-    return { loyaltyStamps: 0, freebiesLeft: 0, vouchers: [] };
+    return { loyaltyStamps: 0, vouchers: [] };
   }
 }


### PR DESCRIPTION
## Summary
- Have `getMyStats` return only loyalty stamp count and voucher codes
- Derive `freebiesLeft` from voucher list in `StatsContext`
- Switch UI components to rely on `stats.vouchers.length` and drop placeholder vouchers

## Testing
- `npm test` *(fails: supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b564014ff8832293ab4b12a8b57377