### PR TITLE
fix: refresh loyalty stats after checkout

### DIFF
--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -322,11 +322,6 @@ export default function CartScreen({ navigation }) {
                     showToast('Failed to refresh stats');
                   }
 
-                  setStats({
-                    loyaltyStamps: loyalty.loyalty_stamps,
-                    vouchers,
-                  });
-
                   if (__DEV__) {
                     console.log(
                       `[LOYALTY] awarded ${stampsToAward}, redeemed ${redeemCount}`,


### PR DESCRIPTION
## Summary
- rely on StatsContext refresh after checkout for canonical loyalty totals
- prevent cart retention by removing undefined variables and ensuring clear executes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5700f5bec832284136d103571b06e