### PR TITLE
Ensure checkout_loyalty migration drops existing function

### DIFF
--- a/supabase/migrations/0017_redefine_checkout_loyalty.sql
+++ b/supabase/migrations/0017_redefine_checkout_loyalty.sql
@@ -14,6 +14,8 @@ BEGIN
   END IF;
 END $$;
 
+DROP FUNCTION IF EXISTS public.checkout_loyalty(uuid, text, int, int);
+
 CREATE FUNCTION public.checkout_loyalty(
   p_user uuid,
   p_order_id text,


### PR DESCRIPTION
## Summary
- Drop existing `checkout_loyalty` before redefining it to allow migration re-runs

## Testing
- `npm test`
- `npx supabase db reset` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b57cc7a4288322a80a6842c2e62954