### PR TITLE
refactor: avoid aggregate FOR UPDATE in checkout_loyalty

### DIFF
--- a/supabase/migrations/0017_redefine_checkout_loyalty.sql
+++ b/supabase/migrations/0017_redefine_checkout_loyalty.sql
@@ -61,14 +61,10 @@ BEGIN
 
   -- current ledger totals
   SELECT COALESCE(SUM(stamps),0) INTO cur_stamps
-    FROM public.loyalty_stamps
-    WHERE user_id = p_user
-    FOR UPDATE;
+      FROM (SELECT stamps FROM public.loyalty_stamps WHERE user_id = p_user FOR UPDATE) s;
 
   SELECT COUNT(*) INTO cur_free
-    FROM public.drink_vouchers
-    WHERE user_id = p_user AND redeemed = FALSE
-    FOR UPDATE;
+      FROM (SELECT 1 FROM public.drink_vouchers WHERE user_id = p_user AND redeemed = FALSE FOR UPDATE) v;
 
   IF inserted > 0 THEN
     -- consume existing free drinks


### PR DESCRIPTION
## Summary
- fix aggregate SELECTs in checkout_loyalty by locking rows in subqueries instead of using FOR UPDATE directly

## Testing
- `npx supabase db reset` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68b57eab7e3083228d36447d6733d63a