### PR TITLE
chore: redefine checkout_loyalty with drop guard

### DIFF
--- a/supabase/migrations/20250901102944_redefine_checkout_loyalty.sql
+++ b/supabase/migrations/20250901102944_redefine_checkout_loyalty.sql
@@ -1,9 +1,22 @@
 -- 20250901102944_redefine_checkout_loyalty.sql
 -- Redefine checkout_loyalty to ledger stamp awards without profile aggregates
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'checkout_loyalty'
+      AND pg_get_function_identity_arguments(p.oid) = 'uuid, text, int, int'
+  ) THEN
+    EXECUTE 'DROP FUNCTION public.checkout_loyalty(uuid, text, int, int)';
+  END IF;
+END $$;
+
 DROP FUNCTION IF EXISTS public.checkout_loyalty(uuid, text, int, int);
 
-CREATE FUNCTION public.checkout_loyalty(
+CREATE OR REPLACE FUNCTION public.checkout_loyalty(
   p_user uuid,
   p_order_id text,
   p_add_stamps int,


### PR DESCRIPTION
## Summary
- drop old `checkout_loyalty` before redefining
- recreate `checkout_loyalty` with `OR REPLACE` to avoid duplicates

## Testing
- `npm test` *(fails: Cannot find module 'node:test')*
- `psql -c "DROP FUNCTION IF EXISTS public.checkout_loyalty(uuid, text, int, int);"` *(fails: connection to server failed)*
- `psql -f supabase/migrations/20250901102944_redefine_checkout_loyalty.sql` *(fails: connection to server failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b583050bf88322becd608b5cd2ac2c