### PR TITLE
Fix checkout loyalty drop function signature

### DIFF
--- a/supabase/migrations/0018_normalize_checkout_loyalty.sql
+++ b/supabase/migrations/0018_normalize_checkout_loyalty.sql
@@ -8,9 +8,9 @@ BEGIN
     JOIN pg_namespace n ON n.oid = p.pronamespace
     WHERE n.nspname = 'public'
       AND p.proname = 'checkout_loyalty'
-      AND pg_get_function_identity_arguments(p.oid) = 'uuid, text, int, int'
+      AND pg_get_function_identity_arguments(p.oid) = 'uuid, text, integer, integer'
   ) THEN
-    EXECUTE 'DROP FUNCTION public.checkout_loyalty(uuid, text, int, int)';
+    EXECUTE 'DROP FUNCTION public.checkout_loyalty(uuid, text, integer, integer)';
   END IF;
 END $$;
 
@@ -123,7 +123,7 @@ BEGIN
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.checkout_loyalty(uuid, text, int, int) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.checkout_loyalty(uuid, text, integer, integer) TO authenticated;
 
 NOTIFY pgrst, 'reload schema';
 


### PR DESCRIPTION
## Summary
- Ensure `checkout_loyalty` replacement check uses canonical `integer` argument types
- Update grant to match the canonical function signature

## Testing
- `npx supabase db push` *(fails: Cannot find project ref. Have you run supabase link?)*

------
https://chatgpt.com/codex/tasks/task_e_68b584d3ec208322a3d261b2b9606f2c