### PR TITLE
fix: drop checkout_loyalty variants before redefine

### DIFF
--- a/supabase/migrations/0018_normalize_checkout_loyalty.sql
+++ b/supabase/migrations/0018_normalize_checkout_loyalty.sql
@@ -1,20 +1,10 @@
 -- 0018_normalize_checkout_loyalty.sql
 -- Normalize loyalty after checkout: convert stamps to vouchers and sync profiles
 
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM pg_proc p
-    JOIN pg_namespace n ON n.oid = p.pronamespace
-    WHERE n.nspname = 'public'
-      AND p.proname = 'checkout_loyalty'
-      AND pg_get_function_identity_arguments(p.oid) = 'uuid, text, integer, integer'
-  ) THEN
-    EXECUTE 'DROP FUNCTION public.checkout_loyalty(uuid, text, integer, integer)';
-  END IF;
-END $$;
+DROP FUNCTION IF EXISTS public.checkout_loyalty(uuid, text, integer, integer);
+DROP FUNCTION IF EXISTS public.checkout_loyalty(uuid, text, int, int);
 
-CREATE FUNCTION public.checkout_loyalty(
+CREATE OR REPLACE FUNCTION public.checkout_loyalty(
   p_user uuid,
   p_order_id text,
   p_add_stamps int,


### PR DESCRIPTION
## Summary
- drop prior `checkout_loyalty` function signatures with explicit `DROP FUNCTION IF EXISTS` calls
- redefine `checkout_loyalty` via `CREATE OR REPLACE FUNCTION` and retain grant using canonical `integer` types

## Testing
- `npx supabase db lint` *(fails: failed to connect to `host=127.0.0.1 user=postgres database=postgres`: dial tcp 127.0.0.1:54322: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b58677f8f8832284449d411a4447f4