### PR TITLE
Lock loyalty tables before aggregation

### DIFF
--- a/supabase/migrations/0018_normalize_checkout_loyalty.sql
+++ b/supabase/migrations/0018_normalize_checkout_loyalty.sql
@@ -51,15 +51,19 @@ BEGIN
   GET DIAGNOSTICS inserted = ROW_COUNT;
 
   -- current ledger totals
-  SELECT COALESCE(SUM(stamps),0) INTO cur_stamps
-    FROM public.loyalty_stamps
-    WHERE user_id = p_user
-    FOR UPDATE;
+  SELECT COALESCE(SUM(stamps), 0) INTO cur_stamps
+    FROM (
+      SELECT stamps FROM public.loyalty_stamps
+      WHERE user_id = p_user
+      FOR UPDATE
+    ) s;
 
   SELECT COUNT(*) INTO cur_free
-    FROM public.drink_vouchers
-    WHERE user_id = p_user AND redeemed = FALSE
-    FOR UPDATE;
+    FROM (
+      SELECT 1 FROM public.drink_vouchers
+      WHERE user_id = p_user AND redeemed = FALSE
+      FOR UPDATE
+    ) v;
 
   IF inserted > 0 THEN
     -- consume existing free drinks
@@ -152,7 +156,9 @@ BEGIN
     RAISE EXCEPTION 'checkout_loyalty mismatch: % %', r.loyalty_stamps, r.free_drinks;
   END IF;
 
-  SELECT SUM(stamps) INTO stamps FROM public.loyalty_stamps WHERE user_id = u;
+  SELECT SUM(ls.stamps) INTO stamps
+    FROM public.loyalty_stamps ls
+    WHERE ls.user_id = u;
   IF stamps <> 1 THEN
     RAISE EXCEPTION 'loyalty_stamps not normalized: %', stamps;
   END IF;


### PR DESCRIPTION
## Summary
- Lock loyalty stamp and voucher rows before aggregating totals in checkout_loyalty migration
- Qualify stamp sum in acceptance test to avoid ambiguous column reference

## Testing
- `npx --yes supabase db lint` *(fails: failed to connect to `host=127.0.0.1 user=postgres database=postgres`: dial tcp 127.0.0.1:54322: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b5886c938083228b87b009116b99b1