### PR TITLE
Lock checkout loyalty row totals separately

### DIFF
--- a/supabase/migrations/20250901102944_redefine_checkout_loyalty.sql
+++ b/supabase/migrations/20250901102944_redefine_checkout_loyalty.sql
@@ -66,16 +66,22 @@ BEGIN
     ON CONFLICT (order_id) DO NOTHING;
   GET DIAGNOSTICS inserted = ROW_COUNT;
 
-  -- current ledger totals
-  SELECT COALESCE(SUM(stamps),0) INTO cur_stamps
-    FROM public.loyalty_stamps
+  -- lock relevant rows then compute current totals
+  PERFORM 1 FROM public.loyalty_stamps
     WHERE user_id = p_user
     FOR UPDATE;
 
-  SELECT COUNT(*) INTO cur_free
-    FROM public.drink_vouchers
+  PERFORM 1 FROM public.drink_vouchers
     WHERE user_id = p_user AND redeemed = FALSE
     FOR UPDATE;
+
+  SELECT COALESCE(SUM(stamps),0) INTO cur_stamps
+    FROM public.loyalty_stamps
+    WHERE user_id = p_user;
+
+  SELECT COUNT(*) INTO cur_free
+    FROM public.drink_vouchers
+    WHERE user_id = p_user AND redeemed = FALSE;
 
   IF inserted > 0 THEN
     -- consume existing free drinks


### PR DESCRIPTION
## Summary
- Lock loyalty stamp and voucher rows before computing totals in `checkout_loyalty`

## Testing
- `npm test` *(fails: The requested module '../lib/supabase.js' does not provide an export named 'hasSupabase'; supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b58fe5db088322a52432eb5bddcb4b