### PR TITLE
Separate aggregates from row locks in loyalty migrations

### DIFF
--- a/supabase/migrations/0015_fix_loyalty_tx.sql
+++ b/supabase/migrations/0015_fix_loyalty_tx.sql
@@ -72,14 +72,17 @@ BEGIN
     ON CONFLICT (order_id) DO NOTHING;
   GET DIAGNOSTICS inserted = ROW_COUNT;
 
-  -- lock profile row and count unredeemed vouchers
+  -- lock profile row and unredeemed vouchers, then count vouchers
   EXECUTE format('SELECT loyalty_stamps FROM public.profiles WHERE %I=$1 FOR UPDATE', pk)
     INTO cur_stamps USING p_user;
 
-  SELECT COUNT(*) INTO cur_free
-    FROM public.drink_vouchers
+  PERFORM 1 FROM public.drink_vouchers
     WHERE user_id = p_user AND redeemed = FALSE
     FOR UPDATE;
+
+  SELECT COUNT(*) INTO cur_free
+    FROM public.drink_vouchers
+    WHERE user_id = p_user AND redeemed = FALSE;
 
   IF inserted > 0 THEN
     -- consume existing free drinks
@@ -102,10 +105,13 @@ BEGIN
     END IF;
 
     -- normalize rewards
-    SELECT COALESCE(SUM(stamps),0) INTO total_stamps
-      FROM public.loyalty_stamps
+    PERFORM 1 FROM public.loyalty_stamps
       WHERE user_id = p_user
       FOR UPDATE;
+
+    SELECT COALESCE(SUM(stamps),0) INTO total_stamps
+      FROM public.loyalty_stamps
+      WHERE user_id = p_user;
 
     vouchers_to_add := total_stamps / 8;
     cur_stamps := MOD(total_stamps, 8);

--- a/supabase/migrations/0017_redefine_checkout_loyalty.sql
+++ b/supabase/migrations/0017_redefine_checkout_loyalty.sql
@@ -60,11 +60,21 @@ BEGIN
   GET DIAGNOSTICS inserted = ROW_COUNT;
 
   -- current ledger totals
+  PERFORM 1 FROM public.loyalty_stamps
+      WHERE user_id = p_user
+      FOR UPDATE;
+
+  PERFORM 1 FROM public.drink_vouchers
+      WHERE user_id = p_user AND redeemed = FALSE
+      FOR UPDATE;
+
   SELECT COALESCE(SUM(stamps),0) INTO cur_stamps
-      FROM (SELECT stamps FROM public.loyalty_stamps WHERE user_id = p_user FOR UPDATE) s;
+      FROM public.loyalty_stamps
+      WHERE user_id = p_user;
 
   SELECT COUNT(*) INTO cur_free
-      FROM (SELECT 1 FROM public.drink_vouchers WHERE user_id = p_user AND redeemed = FALSE FOR UPDATE) v;
+      FROM public.drink_vouchers
+      WHERE user_id = p_user AND redeemed = FALSE;
 
   IF inserted > 0 THEN
     -- consume existing free drinks

--- a/supabase/migrations/0018_normalize_checkout_loyalty.sql
+++ b/supabase/migrations/0018_normalize_checkout_loyalty.sql
@@ -51,19 +51,21 @@ BEGIN
   GET DIAGNOSTICS inserted = ROW_COUNT;
 
   -- current ledger totals
+  PERFORM 1 FROM public.loyalty_stamps
+    WHERE user_id = p_user
+    FOR UPDATE;
+
+  PERFORM 1 FROM public.drink_vouchers
+    WHERE user_id = p_user AND redeemed = FALSE
+    FOR UPDATE;
+
   SELECT COALESCE(SUM(stamps), 0) INTO cur_stamps
-    FROM (
-      SELECT stamps FROM public.loyalty_stamps
-      WHERE user_id = p_user
-      FOR UPDATE
-    ) s;
+    FROM public.loyalty_stamps
+    WHERE user_id = p_user;
 
   SELECT COUNT(*) INTO cur_free
-    FROM (
-      SELECT 1 FROM public.drink_vouchers
-      WHERE user_id = p_user AND redeemed = FALSE
-      FOR UPDATE
-    ) v;
+    FROM public.drink_vouchers
+    WHERE user_id = p_user AND redeemed = FALSE;
 
   IF inserted > 0 THEN
     -- consume existing free drinks


### PR DESCRIPTION
## Summary
- avoid `COUNT/SUM ... FOR UPDATE` in older loyalty migrations by locking rows separately
- maintain idempotent behavior and existing acceptance tests

## Testing
- `npm test` *(fails: supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b59373a9608322821b39525c5ca671