### PR TITLE
refactor: capture award_stamps outputs via record

### DIFF
--- a/supabase/migrations/0012_fix_award_stamps_acceptance.sql
+++ b/supabase/migrations/0012_fix_award_stamps_acceptance.sql
@@ -139,8 +139,8 @@ BEGIN
   ----------------------------------------------------------------
   SELECT * INTO r
   FROM public.award_stamps(u, oid, 3);
-  out_ls := r.loyalty_stamps;
-  out_fd := r.free_drinks;
+  out_ls := r.o_loyalty_stamps;
+  out_fd := r.o_free_drinks;
 
   -- Expect: 5 + 3 = 8 → rolls to 1 free drink, 0 stamps (totals 0,2)
   IF out_ls <> 0 OR out_fd <> 2 THEN
@@ -181,20 +181,23 @@ DECLARE u uuid;
 
 BEGIN
   SELECT id INTO u FROM auth.users LIMIT 1;
-  IF u IS NOT NULL THEN
-    -- Ensure a profile exists
-    INSERT INTO public.profiles(user_id, loyalty_stamps, free_drinks)
-    VALUES (u, 0, 0)
-    ON CONFLICT (user_id) DO NOTHING;
-
-
-    SELECT * INTO r FROM public.award_stamps(u, oid, 1);
-    ls := r.loyalty_stamps;
-    fd := r.free_drinks;
-    RAISE NOTICE 'award_stamps returned ls=%, fd=%', ls, fd;
-    DELETE FROM public.loyalty_awards WHERE order_id=oid;
-
+  IF u IS NULL THEN
+    RAISE NOTICE 'Skipping runtime sanity: no rows in auth.users.';
+    RETURN;
   END IF;
+
+  -- Ensure a profile exists
+  INSERT INTO public.profiles(user_id, loyalty_stamps, free_drinks)
+  VALUES (u, 0, 0)
+  ON CONFLICT (user_id) DO NOTHING;
+
+
+  SELECT * INTO r FROM public.award_stamps(u, oid, 1);
+  ls := r.o_loyalty_stamps;
+  fd := r.o_free_drinks;
+  RAISE NOTICE 'award_stamps returned ls=%, fd=%', ls, fd;
+  DELETE FROM public.loyalty_awards WHERE order_id = oid;
+
 END $$;
 
 -- Reload schema


### PR DESCRIPTION
## Summary
- capture `award_stamps` results into a record and map to `o_` columns in acceptance
- guard runtime sanity block with user existence and record outputs

## Testing
- `npm test` *(fails: The requested module '../lib/supabase.js' does not provide an export named 'hasSupabase'; supabase.from is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b59384d0d883229d23dd5ffbbe6f1e