### PR TITLE
Skip loyalty ledger insert when no stamps

### DIFF
--- a/supabase/migrations/0014_fix_loyalty_for_update.sql
+++ b/supabase/migrations/0014_fix_loyalty_for_update.sql
@@ -17,51 +17,53 @@ AS $$
 DECLARE
   cur_stamps int := 0;
   cur_free   int := 0;
+  inserted   int := 0;
 BEGIN
-  -- If this order already awarded, return current totals (idempotent)
-  IF EXISTS (SELECT 1 FROM public.loyalty_awards WHERE order_id = p_order_id) THEN
-    SELECT COALESCE(p.loyalty_stamps,0), COALESCE(p.free_drinks,0)
+  -- If no stamps to add, ensure profile exists and return current totals
+  IF GREATEST(p_add, 0) = 0 THEN
+    INSERT INTO public.profiles(user_id, loyalty_stamps, free_drinks)
+      VALUES (p_user, 0, 0)
+      ON CONFLICT (user_id) DO NOTHING;
+
+    SELECT COALESCE(loyalty_stamps,0), COALESCE(free_drinks,0)
       INTO loyalty_stamps, free_drinks
-    FROM public.profiles AS p
-    WHERE p.user_id = p_user;
-    loyalty_stamps := COALESCE(loyalty_stamps,0);
-    free_drinks    := COALESCE(free_drinks,0);
+    FROM public.profiles
+    WHERE user_id = p_user;
+
     RETURN;
   END IF;
 
-  -- Ensure a profile row exists
-  INSERT INTO public.profiles AS p (user_id, loyalty_stamps, free_drinks)
-  VALUES (p_user, 0, 0)
-  ON CONFLICT (user_id) DO NOTHING;
+  -- ledger row for idempotency
+  INSERT INTO public.loyalty_awards(order_id, user_id, stamps_awarded)
+    VALUES (p_order_id, p_user, GREATEST(p_add,0))
+    ON CONFLICT (order_id) DO NOTHING;
+  GET DIAGNOSTICS inserted = ROW_COUNT;
 
-  -- If no stamps to add, just read back totals
-  IF COALESCE(p_add,0) <= 0 THEN
-    SELECT COALESCE(p.loyalty_stamps,0), COALESCE(p.free_drinks,0)
-      INTO loyalty_stamps, free_drinks
-    FROM public.profiles AS p
-    WHERE p.user_id = p_user;
+  INSERT INTO public.profiles(user_id, loyalty_stamps, free_drinks)
+    VALUES (p_user, 0, 0)
+    ON CONFLICT (user_id) DO NOTHING;
+
+  SELECT COALESCE(loyalty_stamps,0), COALESCE(free_drinks,0)
+    INTO cur_stamps, cur_free
+  FROM public.profiles
+  WHERE user_id = p_user
+  FOR UPDATE;
+
+  IF inserted = 0 THEN
+    loyalty_stamps := cur_stamps;
+    free_drinks    := cur_free;
     RETURN;
   END IF;
 
-  -- Add stamps
-  UPDATE public.profiles AS p
-  SET loyalty_stamps = COALESCE(p.loyalty_stamps,0) + p_add
-  WHERE p.user_id = p_user
-  RETURNING p.loyalty_stamps, p.free_drinks
-  INTO cur_stamps, cur_free;
-
-  -- Roll into free drinks (8 stamps = 1)
-  cur_free   := COALESCE(cur_free,0) + (cur_stamps / 8);
+  -- Add stamps and roll into free drinks (8 stamps = 1)
+  cur_stamps := cur_stamps + GREATEST(p_add,0);
+  cur_free   := cur_free + (cur_stamps / 8);
   cur_stamps := cur_stamps % 8;
 
-  UPDATE public.profiles AS p
+  UPDATE public.profiles
   SET loyalty_stamps = cur_stamps,
       free_drinks    = cur_free
-  WHERE p.user_id = p_user;
-
-  INSERT INTO public.loyalty_awards(order_id, user_id, stamps_awarded)
-  VALUES (p_order_id, p_user, p_add)
-  ON CONFLICT (order_id) DO NOTHING;
+  WHERE user_id = p_user;
 
   loyalty_stamps := cur_stamps;
   free_drinks    := cur_free;


### PR DESCRIPTION
## Summary
- prevent award_stamps from inserting loyalty ledger rows when zero stamps are added

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a313dfc08322bcc6905095723b27