### PR TITLE
chore: re-version loyalty fix migration

### DIFF
--- a/supabase/migrations/0019_fix_loyalty_for_update.sql
+++ b/supabase/migrations/0019_fix_loyalty_for_update.sql
@@ -1,4 +1,4 @@
--- 0014_fix_loyalty_for_update.sql
+-- 0019_fix_loyalty_for_update.sql
 
 -- redefine award_stamps and harden orders constraints/RLS
 


### PR DESCRIPTION
## Summary
- move loyalty and orders SQL updates into a new 0019 migration

## Testing
- `npx supabase db push --include-all` *(fails: Cannot find project ref. Have you run supabase link?)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4f3f67883229843e0ab8475eef2