### PR TITLE
Add logging for auth, CMS, cart, and loyalty events

### DIFF
--- a/src/context/CartContext.js
+++ b/src/context/CartContext.js
@@ -25,16 +25,19 @@ export function CartProvider({ children }) {
       }
       return [...prev, { ...item, quantity: item.quantity || 1 }];
     });
+    console.log(`[CART] add ${item.id} x${item.quantity || 1}`);
   };
 
   const removeItem = (id) => {
     setItems((prev) => prev.filter((i) => i.id !== id));
+    console.log(`[CART] remove ${id}`);
   };
 
   const incrementItem = (id) => {
     setItems((prev) =>
       prev.map((i) => (i.id === id ? { ...i, quantity: i.quantity + 1 } : i))
     );
+    console.log(`[CART] increment ${id}`);
   };
 
   const decrementItem = (id) => {
@@ -43,6 +46,7 @@ export function CartProvider({ children }) {
         i.id === id ? { ...i, quantity: Math.max(1, i.quantity - 1) } : i
       )
     );
+    console.log(`[CART] decrement ${id}`);
   };
 
   const updateQuantity = (id, delta) => {
@@ -55,10 +59,14 @@ export function CartProvider({ children }) {
             : i
         )
       );
+      console.log(`[CART] update ${id} delta ${delta}`);
     }
   };
 
-  const clear = () => setItems([]);
+  const clear = () => {
+    setItems([]);
+    console.log('[CART] clear');
+  };
 
   const itemCount = items.reduce((sum, i) => sum + i.quantity, 0);
   const subtotal = items.reduce((sum, i) => sum + (i.price || 0) * i.quantity, 0);

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -313,7 +313,10 @@ export default function CartScreen({ navigation }) {
                 } else {
                   const prevStats = stats;
                   try {
-                    await refreshStats(true);
+                    const updated = await refreshStats(true);
+                    console.log(
+                      `[LOYALTY] post-checkout → stamps: ${updated.loyaltyStamps}, free drinks: ${updated.freebiesLeft}`
+                    );
                   } catch (e) {
                     console.warn('[LOYALTY] refreshStats failed:', e);
                     setStats(prevStats);

--- a/src/screens/MembershipStartScreen.js
+++ b/src/screens/MembershipStartScreen.js
@@ -63,7 +63,11 @@ export default function MembershipStartScreen() {
     if (!email || !password) { Alert.alert('Missing details', 'Email and password are required.'); return; }
     const { error } = await supabase.auth.signInWithPassword({ email, password });
     if (error) Alert.alert('Sign in failed', error.message);
-    else { Alert.alert('Welcome back', 'Signed in successfully.'); navigation.navigate('Home'); }
+    else {
+      console.log(`[AUTH] signed in: ${email}`);
+      Alert.alert('Welcome back', 'Signed in successfully.');
+      navigation.navigate('Home');
+    }
   }
 
   async function handleForgot() {

--- a/src/services/cms.js
+++ b/src/services/cms.js
@@ -22,6 +22,7 @@ export async function getCMS(force = false) {
     cached = data;
     globalThis.preloaded = globalThis.preloaded || {};
     globalThis.preloaded.cms = data;
+    console.log(`[CMS] received ${Object.keys(data || {}).length} keys`);
     markLoaded('cms');
     return data;
   } catch {

--- a/src/services/stats.js
+++ b/src/services/stats.js
@@ -26,11 +26,14 @@ export async function getMyStats() {
       console.error('me-stats error', res.status, json);
       return { loyaltyStamps: 0, vouchers: [] };
     }
-
-    return {
+    const result = {
       loyaltyStamps: Number(json?.loyaltyStamps ?? 0),
       vouchers: Array.isArray(json?.vouchers) ? json.vouchers.filter(Boolean) : [],
     };
+    console.log(
+      `[LOYALTY] stats received → stamps: ${result.loyaltyStamps}, free drinks: ${result.vouchers.length}`,
+    );
+    return result;
   } catch (e) {
     console.error('getMyStats failed', e);
     return { loyaltyStamps: 0, vouchers: [] };


### PR DESCRIPTION
## Summary
- log user sign-ins
- report received CMS data and stats for loyalty vouchers
- trace cart changes and loyalty totals after checkout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a6639b188322ad62d547231b50f4