### PR TITLE
docs: explain lock-then-aggregate pattern

### DIFF
--- a/supabase/migrations/20250901102944_redefine_checkout_loyalty.sql
+++ b/supabase/migrations/20250901102944_redefine_checkout_loyalty.sql
@@ -66,7 +66,7 @@ BEGIN
     ON CONFLICT (order_id) DO NOTHING;
   GET DIAGNOSTICS inserted = ROW_COUNT;
 
-  -- lock relevant rows then compute current totals
+  -- lock relevant rows first
   PERFORM 1 FROM public.loyalty_stamps
     WHERE user_id = p_user
     FOR UPDATE;
@@ -75,6 +75,7 @@ BEGIN
     WHERE user_id = p_user AND redeemed = FALSE
     FOR UPDATE;
 
+  -- then compute totals without FOR UPDATE
   SELECT COALESCE(SUM(stamps),0) INTO cur_stamps
     FROM public.loyalty_stamps
     WHERE user_id = p_user;


### PR DESCRIPTION
## Summary
- clarify checkout_loyalty migration: lock loyalty rows before aggregates

## Testing
- `npx supabase db push` *(fails: npm error canceled; project not linked)*
- `npx supabase db query "select * from public.checkout_loyalty('00000000-0000-0000-0000-000000000000','o1',1,0);"` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a7a65a288322a539c0df5a04a30b