### PR TITLE
feat: generate member vouchers from free drinks

### DIFF
--- a/__tests__/loyalty.test.ts
+++ b/__tests__/loyalty.test.ts
@@ -157,7 +157,7 @@ test('specials items are treated as drinks and award stamps', { concurrency: fal
   mkdirSync(libDir, { recursive: true });
   writeFileSync(
     resolve(libDir, 'supabase.js'),
-    'export const hasSupabase = true; export const supabase = {};',
+    "export const hasSupabase = true; export const supabase = { from: () => ({ insert: () => ({ select: () => ({ single: async () => ({ data: { id: 'o1' }, error: null }) }) }) }) };",
   );
   // @ts-ignore
   const { isDrinkItem } = await import('../../src/utils/isDrinkItem.js');

--- a/__tests__/orders.test.ts
+++ b/__tests__/orders.test.ts
@@ -30,7 +30,8 @@ test('saveReceiptForUser logs source app', async () => {
     resolve(libDir, 'supabase.js'),
     "export const supabase = { from: () => ({ insert: () => ({ select: () => ({ single: async () => ({ data: { id: 'o1' }, error: null }) }) }) }) };"
   );
-  const { saveReceiptForUser } = await import('../src/services/orders.js');
+  // @ts-ignore
+  const { saveReceiptForUser } = await import('../src/services/orders.js?test');
 
   const log = mock.method(console, 'log');
   await saveReceiptForUser('u1', {

--- a/supabase/functions/member-qrs/index.ts
+++ b/supabase/functions/member-qrs/index.ts
@@ -26,17 +26,19 @@ serve(async (req: Request) => {
 
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
-  // fetch existing unredeemed vouchers
-  const { data: vouchers } = await admin
-    .from("drink_vouchers")
-    .select("code")
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("free_drinks")
     .eq("user_id", member_uuid)
-    .eq("redeemed", false);
+    .maybeSingle();
+
+  const count = Number(profile?.free_drinks ?? 0);
+  const vouchers = Array.from({ length: count }, () => `ruminate:voucher:${crypto.randomUUID()}`);
 
   return new Response(
     JSON.stringify({
       payload: `ruminate:member:${member_uuid}`,
-      vouchers: (vouchers ?? []).map((v) => `ruminate:voucher:${v.code}`),
+      vouchers,
     }),
     { headers: { ...cors(), "content-type": "application/json" } }
   );


### PR DESCRIPTION
## Summary
- read free_drink count from profiles for member QR payloads
- generate voucher codes on the fly from free_drink totals
- stabilize tests with isolated Supabase stubs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b698109b188322816c9b7063404d3c