### PR TITLE
refactor voucher redemption

### DIFF
--- a/src/services/vouchers.js
+++ b/src/services/vouchers.js
@@ -12,14 +12,14 @@ export async function syncVouchers() {
   }
 }
 
-export async function redeemVoucher(code, refreshStats) {
+export async function redeemVoucher(_code, refreshStats) {
   if (!hasSupabase || !supabase) return { success: false, message: 'Redeem service unavailable' };
-  const { data, error } = await supabase.functions.invoke('voucher-redeem', { body: { code } });
+  const { data, error } = await supabase.functions.invoke('voucher-redeem', { body: {} });
   const success = !error && (data?.success ?? false);
   if (success) {
     // Loyalty values change after redemption; bypass any cached stats
     await refreshStats?.(true);
     return { success: true };
   }
-  return { success: false, message: 'Invalid or already redeemed voucher' };
+  return { success: false, message: 'No vouchers available' };
 }

--- a/supabase/functions/loyalty-redeem/index.ts
+++ b/supabase/functions/loyalty-redeem/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { applyStampAccrual, normalizeRewards } from "../_shared/rewards.ts";
+import { applyStampAccrual } from "../_shared/rewards.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
@@ -24,12 +24,26 @@ serve(async (req: Request) => {
   if (!user) return new Response("Unauthorized", { status: 401, headers: cors() });
 
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
-  const { data: stampRows } = await admin
-    .from("loyalty_stamps")
-    .select("id, stamps")
-    .eq("user_id", user.id);
-  const total = (stampRows ?? []).reduce((sum, r) => sum + (r.stamps || 0), 0);
+
+  let pk = "id";
+  const { error: userIdColErr } = await admin.from("profiles").select("user_id").limit(1);
+  if (!userIdColErr) {
+    pk = "user_id";
+  } else {
+    const { error: idColErr } = await admin.from("profiles").select("id").limit(1);
+    if (idColErr) throw idColErr;
+  }
+
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("loyalty_stamps, free_drinks")
+    .eq(pk, user.id)
+    .single();
+
+  const total = profile?.loyalty_stamps ?? 0;
+  const currentFree = profile?.free_drinks ?? 0;
   const { vouchersEarned, stampsRemainder } = applyStampAccrual(0, total);
+
   if (vouchersEarned === 0) {
     return new Response(JSON.stringify({ success: false }), {
       status: 200,
@@ -37,18 +51,13 @@ serve(async (req: Request) => {
     });
   }
 
-  await admin.from("loyalty_stamps").delete().eq("user_id", user.id);
-  if (stampsRemainder > 0) {
-    await admin.from("loyalty_stamps").insert({ user_id: user.id, stamps: stampsRemainder });
-  }
-
-  const voucherRows = Array.from({ length: vouchersEarned }, () => ({
-    user_id: user.id,
-    code: crypto.randomUUID(),
-  }));
-  await admin.from("drink_vouchers").insert(voucherRows);
-
-  await normalizeRewards(admin, user.id);
+  await admin
+    .from("profiles")
+    .update({
+      loyalty_stamps: stampsRemainder,
+      free_drinks: currentFree + vouchersEarned,
+    })
+    .eq(pk, user.id);
 
   return new Response(JSON.stringify({ success: true }), {
     status: 200,

--- a/supabase/functions/voucher-redeem/index.ts
+++ b/supabase/functions/voucher-redeem/index.ts
@@ -22,22 +22,38 @@ serve(async (req: Request) => {
   const { data: { user } } = await auth.auth.getUser();
   if (!user) return new Response("Unauthorized", { status: 401, headers: cors() });
 
-  let body: any = {};
-  try { body = await req.json(); } catch {}
-  const code = body?.code as string | undefined;
-  if (!code) {
-    return new Response(JSON.stringify({ success: false, error: "code required" }), { status: 400, headers: { ...cors(), "content-type": "application/json" } });
+  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  let pk = "id";
+  const { error: userIdColErr } = await admin.from("profiles").select("user_id").limit(1);
+  if (!userIdColErr) {
+    pk = "user_id";
+  } else {
+    const { error: idColErr } = await admin.from("profiles").select("id").limit(1);
+    if (idColErr) throw idColErr;
   }
 
-  const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
-  const { data, error } = await admin
-    .from("drink_vouchers")
-    .update({ redeemed: true, redeemed_at: new Date().toISOString() })
-    .eq("code", code)
-    .eq("user_id", user.id)
-    .eq("redeemed", false)
-    .select("id");
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("free_drinks")
+    .eq(pk, user.id)
+    .single();
 
-  const success = !error && (data?.length ?? 0) > 0;
-  return new Response(JSON.stringify({ success }), { status: success ? 200 : 400, headers: { ...cors(), "content-type": "application/json" } });
+  const freebies = profile?.free_drinks ?? 0;
+  if (freebies <= 0) {
+    return new Response(JSON.stringify({ success: false }), {
+      status: 400,
+      headers: { ...cors(), "content-type": "application/json" },
+    });
+  }
+
+  await admin
+    .from("profiles")
+    .update({ free_drinks: freebies - 1 })
+    .eq(pk, user.id);
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { ...cors(), "content-type": "application/json" },
+  });
 });


### PR DESCRIPTION
## Summary
- update loyalty-redeem to compute vouchers from profile counters
- decrement profile free_drinks during voucher-redeem
- adjust voucher service for new redeem endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b698132a388322979220c91985ec81