### PR TITLE
Refactor loyalty to profile counters

### DIFF
--- a/__tests__/loyalty.test.ts
+++ b/__tests__/loyalty.test.ts
@@ -90,7 +90,7 @@ test('awardStamps rollover with idempotency', () => {
   assert.deepEqual(profile, { stamps: 2, freebies: 1 });
 });
 
-test('awardStamps caps stamps at 7 and increments free drinks', { concurrency: false }, async () => {
+test('checkoutLoyalty caps stamps at 7 and increments free drinks', { concurrency: false }, async () => {
   const dir = dirname(fileURLToPath(import.meta.url));
   const libDir = resolve(dir, '../src/lib');
   mkdirSync(libDir, { recursive: true });
@@ -99,13 +99,16 @@ test('awardStamps caps stamps at 7 and increments free drinks', { concurrency: f
     `export const hasSupabase = true;
 const state = { stamps: 0, free: 0 };
 export const supabase = {
-  rpc: (_fn, { p_add }) => {
-    const total = state.stamps + p_add;
+  rpc: (_fn, { p_add_stamps, p_redeem }) => {
+    const add = Number(p_add_stamps || 0);
+    const redeem = Math.min(Number(p_redeem || 0), state.free);
+    state.free -= redeem;
+    const total = state.stamps + add;
     state.free += Math.floor(total / 8);
     state.stamps = total % 8;
     return {
       maybeSingle: async () => ({
-        data: { o_loyalty_stamps: state.stamps, o_free_drinks: state.free },
+        data: { loyalty_stamps: state.stamps, free_drinks: state.free },
         error: null,
       }),
     };
@@ -114,37 +117,15 @@ export const supabase = {
   );
   const svcDir = resolve(dir, '../src/services');
   mkdirSync(svcDir, { recursive: true });
-  writeFileSync(
-    resolve(svcDir, 'loyalty.js'),
-    `import { supabase, hasSupabase } from '../lib/supabase.js';
-export async function awardStamps(p_user, p_order_id, p_add){
-  if(!hasSupabase || !supabase) return { data: null, error: new Error('no supabase') };
-  try {
-    const { data: rawData, error } = await supabase
-      .rpc('award_stamps', { p_user, p_order_id, p_add })
-      .maybeSingle();
-    const data = rawData ?? { o_loyalty_stamps: 0, o_free_drinks: 0 };
-    if(!error){
-      console.log(
-        \`[LOYALTY] awarding: +\${p_add} stamp(s); new free drinks: \${data.o_free_drinks}; loyalty stamps: \${data.o_loyalty_stamps}\`
-      );
-      console.assert(data.o_loyalty_stamps <= 7, 'o_loyalty_stamps exceeded 7');
-    }
-    return { data, error };
-  } catch(error){
-    return { data: null, error };
-  }
-}
-`
-  );
-  const { awardStamps } = await import('../src/services/loyalty.js');
+  copyFileSync(resolve(dir, '../../src/services/loyalty.js'), resolve(svcDir, 'loyalty.js'));
+  const { checkoutLoyalty } = await import('../src/services/loyalty.js');
   const log = mock.method(console, 'log');
-  let { data } = await awardStamps('u1', 'o1', 5);
-  assert.equal(data?.o_loyalty_stamps, 5);
-  assert.equal(data?.o_free_drinks, 0);
-  ({ data } = await awardStamps('u1', 'o2', 4));
-  assert.equal(data?.o_loyalty_stamps, 1);
-  assert.equal(data?.o_free_drinks, 1);
+  let { data } = await checkoutLoyalty('u1', 'o1', 5, 0);
+  assert.equal(data?.loyalty_stamps, 5);
+  assert.equal(data?.free_drinks, 0);
+  ({ data } = await checkoutLoyalty('u1', 'o2', 4, 0));
+  assert.equal(data?.loyalty_stamps, 1);
+  assert.equal(data?.free_drinks, 1);
   assert.ok(
     log.mock.calls.some((c) => String(c.arguments[0]).includes('new free drinks: 1'))
   );

--- a/scripts/grant-rewards.js
+++ b/scripts/grant-rewards.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
-import crypto from 'node:crypto';
-import { applyStampAccrual } from '../src/utils/rewards.js';
 
 const [,, email, freeDrinksArg, stampsArg] = process.argv;
 if (!email) {
@@ -44,41 +42,14 @@ async function getUserByEmailOrList(email) {
 const user = await getUserByEmailOrList(email);
 const uid = user.id;
 
-let voucherRows = [];
-
-if (stampsToAdd > 0) {
-  const { vouchersEarned, stampsRemainder } = applyStampAccrual(0, stampsToAdd);
-  if (stampsRemainder > 0) {
-    const { error } = await supabase
-      .from('loyalty_stamps')
-      .insert([{ user_id: uid, stamps: stampsRemainder }], { returning: 'minimal' });
-    if (error) throw error;
-  }
-  if (vouchersEarned > 0) {
-    voucherRows.push(
-      ...Array.from({ length: vouchersEarned }, () => ({
-        user_id: uid,
-        code: crypto.randomUUID(),
-        redeemed: false,
-      }))
-    );
-  }
-}
-
-if (freeDrinksToAdd > 0) {
-  voucherRows.push(
-    ...Array.from({ length: freeDrinksToAdd }, () => ({
-      user_id: uid,
-      code: crypto.randomUUID(),
-      redeemed: false,
-    }))
-  );
-}
-
-if (voucherRows.length > 0) {
-  const { error } = await supabase
-    .from('drink_vouchers')
-    .insert(voucherRows, { returning: 'minimal' });
+const totalAdd = stampsToAdd + freeDrinksToAdd * 8;
+if (totalAdd > 0) {
+  const { error } = await supabase.rpc('checkout_loyalty', {
+    p_user: uid,
+    p_order_id: `script_${Date.now()}`,
+    p_add_stamps: totalAdd,
+    p_redeem: 0,
+  }).maybeSingle();
   if (error) throw error;
 }
 

--- a/scripts/normalize-all-rewards.js
+++ b/scripts/normalize-all-rewards.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import 'dotenv/config';
-import crypto from 'node:crypto';
 import { createAdminClient } from './_supabase.js';
 import { applyStampAccrual } from '../src/utils/rewards.js';
 
@@ -22,61 +21,33 @@ async function listAllUserIds() {
 
 const userIds = await listAllUserIds();
 
+let pk = 'id';
+const { error: userIdColErr } = await supabase.from('profiles').select('user_id').limit(1);
+if (!userIdColErr) pk = 'user_id';
+
 for (const uid of userIds) {
-  const { data: stampAgg, error: stampErr } = await supabase
-    .from('loyalty_stamps')
-    .select('sum:stamps')
-    .eq('user_id', uid)
-    .maybeSingle();
-  if (stampErr) throw stampErr;
-  const totalStamps = stampAgg?.sum ?? 0;
-
-  const { data: vouchers, error: vouchersErr } = await supabase
-    .from('drink_vouchers')
-    .select('id')
-    .eq('user_id', uid);
-  if (vouchersErr) throw vouchersErr;
-  const existing = vouchers?.length ?? 0;
-
-  const { vouchersEarned, stampsRemainder } = applyStampAccrual(0, totalStamps);
-  const toAdd = vouchersEarned - existing;
-  if (toAdd > 0) {
-    const rows = Array.from({ length: toAdd }, () => ({
-      user_id: uid,
-      code: crypto.randomUUID(),
-    }));
-    const { error: insErr } = await supabase.from('drink_vouchers').insert(rows);
-    if (insErr) throw insErr;
-  }
-
-  if (totalStamps !== stampsRemainder) {
-    const { error: delErr } = await supabase.from('loyalty_stamps').delete().eq('user_id', uid);
-    if (delErr) throw delErr;
-    if (stampsRemainder > 0) {
-      const { error: insErr2 } = await supabase
-        .from('loyalty_stamps')
-        .insert({ user_id: uid, stamps: stampsRemainder });
-      if (insErr2) throw insErr2;
-    }
-  }
-
-  const { data: unredeemed, error: unredeemedErr } = await supabase
-    .from('drink_vouchers')
-    .select('id')
-    .eq('user_id', uid)
-    .eq('redeemed', false);
-  if (unredeemedErr) throw unredeemedErr;
-
-  let pk = 'id';
-  const { error: userIdColErr } = await supabase.from('profiles').select('user_id').limit(1);
-  if (!userIdColErr) pk = 'user_id';
-
-  const { error: profileErr } = await supabase
+  const { data: profile, error: profileErr } = await supabase
     .from('profiles')
-    .update({ loyalty_stamps: stampsRemainder, free_drinks: unredeemed.length })
-    .eq(pk, uid);
+    .select('loyalty_stamps, free_drinks')
+    .eq(pk, uid)
+    .maybeSingle();
   if (profileErr) throw profileErr;
+
+  const currentStamps = profile?.loyalty_stamps ?? 0;
+  const currentFree = profile?.free_drinks ?? 0;
+
+  const { vouchersEarned, stampsRemainder } = applyStampAccrual(currentStamps, 0);
+
+  if (vouchersEarned > 0 || stampsRemainder !== currentStamps) {
+    const { error: updErr } = await supabase
+      .from('profiles')
+      .update({
+        loyalty_stamps: stampsRemainder,
+        free_drinks: currentFree + vouchersEarned,
+      })
+      .eq(pk, uid);
+    if (updErr) throw updErr;
+  }
 
   console.log(`[SCRIPT] Normalized rewards for user ${uid}`);
 }
-

--- a/scripts/reset-rewards.js
+++ b/scripts/reset-rewards.js
@@ -39,11 +39,15 @@ async function getUserByEmailOrList(email) {
 const user = await getUserByEmailOrList(email);
 const uid = user.id;
 
-const { error: e1 } = await supabase.from('drink_vouchers').delete().eq('user_id', uid);
-if (e1) throw e1;
+let pk = 'id';
+const { error: userIdColErr } = await supabase.from('profiles').select('user_id').limit(1);
+if (!userIdColErr) pk = 'user_id';
 
-const { error: e2 } = await supabase.from('loyalty_stamps').delete().eq('user_id', uid);
-if (e2) throw e2;
+const { error } = await supabase
+  .from('profiles')
+  .update({ loyalty_stamps: 0, free_drinks: 0 })
+  .eq(pk, uid);
+if (error) throw error;
 
 console.log(`[SCRIPT] Reset free drinks and loyalty stamps for ${email}`);
 

--- a/supabase/functions/create-order/index.ts
+++ b/supabase/functions/create-order/index.ts
@@ -1,11 +1,9 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { normalizeRewards } from "../_shared/rewards.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-const FUNCTIONS_URL = Deno.env.get("FUNCTIONS_URL")!;
 
 type MenuItem = { price: number; hot: boolean };
 const MENU: Record<string, MenuItem> = {
@@ -44,6 +42,7 @@ serve(async (req) => {
   const syrupShots = Number(body.syrupShots) || 0;
   const payItForward = Number(body.payItForward) || 0;
   const voucherCodes: string[] = Array.isArray(body.voucherCodes) ? body.voucherCodes : [];
+  const redeemCount = voucherCodes.length;
   const timeslot = typeof body.timeslot === "string" ? body.timeslot : null;
 
   let total = 0;
@@ -62,19 +61,7 @@ serve(async (req) => {
   total += SYRUP_PRICE * syrupShots;
   total += PIF_PRICE * payItForward;
 
-  for (const code of voucherCodes) {
-    const res = await fetch(`${FUNCTIONS_URL}/voucher-redeem`, {
-      method: "POST",
-      headers: { "content-type": "application/json", Authorization: authHeader },
-      body: JSON.stringify({ code }),
-    });
-    const j = await res.json().catch(() => null);
-    if (!res.ok || !j?.success) {
-      return new Response(JSON.stringify({ error: `voucher ${code} failed` }), { status: 400, headers: { ...cors(), "content-type": "application/json" } });
-    }
-  }
-
-  total -= VOUCHER_VALUE * voucherCodes.length;
+  total -= VOUCHER_VALUE * redeemCount;
   if (total < 0) total = 0;
 
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
@@ -133,10 +120,14 @@ serve(async (req) => {
     await admin.from("pif_ledger").insert({ type: "purchase", count: payItForward, source_order_id: orderId });
   }
 
-  if (hotCount > 0) {
-    await admin.from("loyalty_stamps").insert({ user_id: user.id, stamps: hotCount });
+  if (hotCount > 0 || redeemCount > 0) {
+    await admin.rpc("checkout_loyalty", {
+      p_user: user.id,
+      p_order_id: orderId,
+      p_add_stamps: hotCount,
+      p_redeem: redeemCount,
+    });
   }
-  await normalizeRewards(admin, user.id);
 
   return new Response(JSON.stringify({ orderId, pickup_code, total_cents: total }), {
     status: 200,

--- a/supabase/functions/member-lookup/index.ts
+++ b/supabase/functions/member-lookup/index.ts
@@ -28,19 +28,10 @@ serve(async (req: Request) => {
 
   let uuid = member_uuid;
   if (!uuid && voucher_code) {
-    const { data: voucher } = await admin
-      .from("drink_vouchers")
-      .select("user_id")
-      .eq("code", voucher_code)
-      .eq("redeemed", false)
-      .maybeSingle();
-    uuid = voucher?.user_id ?? null;
-    if (!uuid) {
-      return new Response(JSON.stringify({ error: "voucher not found" }), {
-        status: 404,
-        headers: { ...cors(), "content-type": "application/json" },
-      });
-    }
+    return new Response(JSON.stringify({ error: "voucher codes deprecated" }), {
+      status: 400,
+      headers: { ...cors(), "content-type": "application/json" },
+    });
   }
 
   const { data: profile } = await admin.from("profiles").select("tier").eq("user_id", uuid).maybeSingle();


### PR DESCRIPTION
## Summary
- update edge functions to use profile counters via `checkout_loyalty`
- drop legacy loyalty table references from scripts
- adjust member lookup and tests for voucher-free rewards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b699d08a6c8322a0a67506e7b5d9a0