### PR TITLE
refactor: track free drink count

### DIFF
--- a/src/components/FreeDrinksCounter.js
+++ b/src/components/FreeDrinksCounter.js
@@ -7,7 +7,7 @@ import { StatsContext } from '../context/StatsContext';
 
 export default function FreeDrinksCounter() {
   const { stats } = useContext(StatsContext);
-  const count = Math.max(0, Number(stats?.vouchers?.length || 0));
+  const count = Math.max(0, Number(stats?.vouchers || 0));
   const limit = 3;
   const ratio = Math.max(0, Math.min(1, count / limit));
   const size = 64;

--- a/src/components/membership/MembershipSignedInPanel.js
+++ b/src/components/membership/MembershipSignedInPanel.js
@@ -58,7 +58,7 @@ export default function MembershipSignedInPanel({ summary, stats, user }) {
         <View style={styles.gridRow}>
           <Stat
             label="Free drinks left"
-            value={stats.vouchers?.length ?? 0}
+            value={Number(stats.vouchers ?? 0)}
           />
           <Stat
             label="Dividends pending"

--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -6,8 +6,8 @@ import { markLoaded } from '../boot/loadingSignals';
 import { supabase } from '../lib/supabase';
 
 export const StatsContext = createContext({
-  stats: { loyaltyStamps: 0, vouchers: [], freebiesLeft: 0 },
-  refreshStats: async () => ({ loyaltyStamps: 0, vouchers: [], freebiesLeft: 0 }),
+  stats: { loyaltyStamps: 0, vouchers: 0, freebiesLeft: 0 },
+  refreshStats: async () => ({ loyaltyStamps: 0, vouchers: 0, freebiesLeft: 0 }),
   setStats: () => {},
 });
 
@@ -15,26 +15,24 @@ export function StatsProvider({ children }) {
 
   const initialRaw = globalThis.preloaded?.stats || {
     loyaltyStamps: 0,
-    vouchers: [],
+    vouchers: 0,
   };
   const initial = {
     loyaltyStamps: Number(initialRaw.loyaltyStamps) || 0,
-    vouchers: Array.isArray(initialRaw.vouchers)
-      ? initialRaw.vouchers.filter(Boolean)
-      : [],
+    vouchers: Number(initialRaw.vouchers) || 0,
   };
-  initial.freebiesLeft = initial.vouchers.length;
+  initial.freebiesLeft = initial.vouchers;
 
   const [stats, setStatsState] = useState(initial);
   const statsRef = useRef(initial);
 
   const applyStats = useCallback((s) => {
 
-    const vouchers = Array.isArray(s.vouchers) ? s.vouchers.filter(Boolean) : [];
+    const vouchers = Number(s.vouchers) || 0;
     const next = {
       loyaltyStamps: Number(s.loyaltyStamps) || 0,
       vouchers,
-      freebiesLeft: vouchers.length,
+      freebiesLeft: vouchers,
     };
     statsRef.current = next;
     setStatsState(next);
@@ -60,12 +58,12 @@ export function StatsProvider({ children }) {
         );
         s.loyaltyStamps = stampsRemainder;
         if (vouchersEarned > 0) {
-          s.vouchers = Array.isArray(s.vouchers) ? s.vouchers : [];
+          s.vouchers = Number(s.vouchers) || 0;
         }
       }
       const decorated = {
         ...s,
-        freebiesLeft: Array.isArray(s.vouchers) ? s.vouchers.length : 0,
+        freebiesLeft: Number(s.vouchers) || 0,
       };
       applyStats(decorated);
       markLoaded('stamps');
@@ -80,7 +78,7 @@ export function StatsProvider({ children }) {
 
   useEffect(() => {
     if (!supabase?.auth) return;
-    const zero = { loyaltyStamps: 0, vouchers: [] };
+    const zero = { loyaltyStamps: 0, vouchers: 0 };
     const sub = supabase.auth.onAuthStateChange(async (event, session) => {
       if (!session?.user) {
         applyStats(zero);

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -18,13 +18,13 @@ import { checkoutLoyalty } from '../services/loyalty';
 
 export default function CartScreen({ navigation }) {
   const insets = useSafeAreaInsets();
-  const { stats = { vouchers: [] }, refreshStats, setStats } =
+  const { stats = { vouchers: 0 }, refreshStats, setStats } =
     useContext(StatsContext) || {
-      stats: { vouchers: [] },
+      stats: { vouchers: 0 },
       refreshStats: async () => {},
       setStats: () => {},
     };
-  const freeDrinks = stats?.vouchers?.length ?? 0;
+  const freeDrinks = Number(stats?.vouchers ?? 0);
   const { setHasOrders, refreshOrdersPresence } = useOrdersPresence();
 
   const showToast = (msg) => {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -136,7 +136,7 @@ export default function HomeScreen({ navigation }) {
               <LoyaltyStampTile count={stats.loyaltyStamps} />
             </View>
 
-            {(member?.tier === 'paid' || (stats.vouchers?.length ?? 0) > 0) && (
+            {(member?.tier === 'paid' || Number(stats.vouchers ?? 0) > 0) && (
                 <View style={{ marginTop: 16 }}>
                   <FreeDrinksCounter />
                 </View>

--- a/src/screens/MembershipScreen.js
+++ b/src/screens/MembershipScreen.js
@@ -35,7 +35,7 @@ export default function MembershipScreen({ navigation }) {
   const [summary, setSummary] = useState({ signedIn: false, tier: 'free', status: 'none', next_billing_at: null });
   const [pifSelfCents, setPifSelfCents] = useState(0);
   const { stats, refreshStats } = useContext(StatsContext);
-  const vouchersKey = Array.isArray(stats?.vouchers) ? stats.vouchers.join(',') : '';
+  const vouchersKey = String(stats?.vouchers ?? 0);
   const [memberPayload, setMemberPayload] = useState('ruminate:member');
   const [page, setPage] = useState(0);
   const [user, setUser] = useState(null);
@@ -43,17 +43,17 @@ export default function MembershipScreen({ navigation }) {
   const pagerRef = useRef(null);
   const [refreshing, setRefreshing] = useState(false);
 
-  const vouchers = React.useMemo(() => {
-    if (Array.isArray(stats?.vouchers)) {
-      return stats.vouchers.map((code) => ({
-        id: code,
-        code,
+  const voucherCount = Number(stats?.vouchers ?? 0);
+  const vouchers = React.useMemo(
+    () =>
+      Array.from({ length: voucherCount }, (_, i) => ({
+        id: String(i),
+        code: null,
         used: false,
         expiresAt: null,
-      }));
-    }
-    return [];
-  }, [vouchersKey]);
+      })),
+    [voucherCount]
+  );
 
   const isExpired = React.useCallback((iso) => {
     if (!iso) return false;
@@ -62,7 +62,7 @@ export default function MembershipScreen({ navigation }) {
 
   const visibleVouchers = React.useMemo(
     () => vouchers.filter(v => !v.used && !isExpired(v.expiresAt)),
-    [vouchers, isExpired, vouchersKey]
+    [vouchers, isExpired, voucherCount]
   );
 
   const pageCount = 1 + visibleVouchers.length;
@@ -133,7 +133,7 @@ export default function MembershipScreen({ navigation }) {
 
   useEffect(() => {
     const prev = prevFreebies.current;
-    const curr = stats?.vouchers?.length ?? 0;
+    const curr = Number(stats?.vouchers ?? 0);
     if (curr - prev === 1) {
       Alert.alert('Free drink earned', 'A free drink voucher has been added to your account.');
       setNotice("You've earned a free drink!");
@@ -143,7 +143,7 @@ export default function MembershipScreen({ navigation }) {
     }
     prevFreebies.current = curr;
     if (curr === 0) setNotice('');
-  }, [stats?.vouchers?.length]);
+  }, [stats?.vouchers]);
 
   const handleAddToWallet = useCallback(async () => {
     try {
@@ -161,7 +161,7 @@ export default function MembershipScreen({ navigation }) {
       <View style={[styles.header, { paddingTop: insets.top }]}><Text style={styles.headerTitle}>Membership</Text></View>
       <ScrollView refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />} contentContainerStyle={styles.content}>
         <Text style={styles.title}>Membership</Text>
-        {notice && (stats?.vouchers?.length ?? 0) > 0 ? (
+        {notice && Number(stats?.vouchers ?? 0) > 0 ? (
           <Text style={styles.notice}>{notice}</Text>
         ) : null}
 
@@ -222,7 +222,7 @@ export default function MembershipScreen({ navigation }) {
               )}
             </View>
 
-            {(summary.tier === 'paid' || (stats?.vouchers?.length ?? 0) > 0) && (
+            {(summary.tier === 'paid' || Number(stats?.vouchers ?? 0) > 0) && (
               <View style={{ marginTop: 14 }}>
                 <FreeDrinksCounter />
               </View>

--- a/src/screens/ScanScreen.js
+++ b/src/screens/ScanScreen.js
@@ -55,17 +55,16 @@ async function loadScanner() {
                   const { data: res } = await supabase.functions.invoke('member-lookup',{ body:{ member_uuid } });
                   setInfo(res);
                 } else if(content.startsWith('voucher:')){
-                  const voucher_code=content.slice('voucher:'.length);
                   try {
-                    const { success, message } = await redeemVoucher(voucher_code, refreshStats);
+                    const { success, message } = await redeemVoucher(refreshStats);
                     if (!success) {
                       showToast(message || 'Invalid voucher');
                       return;
                     }
-                    const { data: res } = await supabase.functions.invoke('member-lookup',{ body:{ voucher_code } });
-                    setInfo(res);
+                    showToast('Voucher redeemed');
+                    setInfo(null);
                   } catch {
-                    showToast('Failed to refresh stats');
+                    showToast('Failed to redeem voucher');
                   }
                 }
               } catch(err){ console.log('lookup failed', err); }

--- a/src/services/qr.js
+++ b/src/services/qr.js
@@ -2,13 +2,13 @@ import { supabase, hasSupabase } from '../lib/supabase';
 
 export async function getMemberQRCodes(userId) {
   if (!hasSupabase || !supabase || !userId) {
-    return { payload: `ruminate:member:${userId}`, vouchers: [] };
+    return { payload: `ruminate:member:${userId}` };
   }
 
   try {
     const { data } = await supabase.functions.invoke('member-qrs', { body: { member_uuid: userId } });
-    return data || { payload: `ruminate:member:${userId}`, vouchers: [] };
+    return data || { payload: `ruminate:member:${userId}` };
   } catch {
-    return { payload: `ruminate:member:${userId}`, vouchers: [] };
+    return { payload: `ruminate:member:${userId}` };
   }
 }

--- a/src/services/vouchers.js
+++ b/src/services/vouchers.js
@@ -2,17 +2,17 @@ import { supabase, hasSupabase } from '../lib/supabase';
 
 export async function syncVouchers() {
   if (!hasSupabase || !supabase) {
-    return [];
+    return 0;
   }
   try {
     const { data } = await supabase.functions.invoke('vouchers-sync', { body: {} });
-    return data?.vouchers ?? [];
+    return Number(data?.vouchers) || 0;
   } catch {
-    return [];
+    return 0;
   }
 }
 
-export async function redeemVoucher(_code, refreshStats) {
+export async function redeemVoucher(refreshStats) {
   if (!hasSupabase || !supabase) return { success: false, message: 'Redeem service unavailable' };
   const { data, error } = await supabase.functions.invoke('voucher-redeem', { body: {} });
   const success = !error && (data?.success ?? false);

--- a/supabase/functions/member-qrs/index.ts
+++ b/supabase/functions/member-qrs/index.ts
@@ -33,12 +33,11 @@ serve(async (req: Request) => {
     .maybeSingle();
 
   const count = Number(profile?.free_drinks ?? 0);
-  const vouchers = Array.from({ length: count }, () => `ruminate:voucher:${crypto.randomUUID()}`);
 
   return new Response(
     JSON.stringify({
       payload: `ruminate:member:${member_uuid}`,
-      vouchers,
+      free_drinks: count,
     }),
     { headers: { ...cors(), "content-type": "application/json" } }
   );


### PR DESCRIPTION
## Summary
- drop voucher code generation in member QR function
- treat free drink vouchers as numeric counts across client services and UI
- redeem scanner vouchers without referencing deprecated codes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b69d2fd5f48322a384586a3e90d16d