### PR TITLE
refactor: fetch profile rewards directly

### DIFF
--- a/supabase/functions/_shared/rewards.ts
+++ b/supabase/functions/_shared/rewards.ts
@@ -10,8 +10,7 @@ export function applyStampAccrual(prevStamps: number, delta: number) {
   };
 }
 
-export async function normalizeRewards(admin: SupabaseClient, userId: string) {
-
+export async function getProfileRewards(admin: SupabaseClient, userId: string) {
   // Determine profiles primary key column
   let pk = "id";
   const { error: userIdColErr } = await admin
@@ -28,55 +27,15 @@ export async function normalizeRewards(admin: SupabaseClient, userId: string) {
     if (idColErr) throw idColErr;
   }
 
-  // Fetch current profile totals
-  const { data: profile, error: fetchErr } = await admin
+  const { data, error } = await admin
     .from("profiles")
     .select("loyalty_stamps, free_drinks")
     .eq(pk, userId)
     .single();
-  if (fetchErr) throw fetchErr;
-
-  const currentStamps = Number(profile?.loyalty_stamps ?? 0);
-  const currentFree = Number(profile?.free_drinks ?? 0);
-
-  // Sum all earned stamps and vouchers redeemed from ledger
-  const { data: txAgg, error: txErr } = await admin
-    .from("loyalty_tx")
-    .select("sum(stamps_awarded) as stamps, sum(vouchers_redeemed) as redeemed")
-    .eq("user_id", userId);
-  if (txErr) throw txErr;
-  const awarded = Number(txAgg?.[0]?.stamps ?? 0);
-  const spent = Number(txAgg?.[0]?.redeemed ?? 0);
-  const totalEarned = Math.max(0, awarded - spent * 8);
-
-  // Determine new stamps to apply beyond those already recorded on the profile
-  const processed = currentStamps + currentFree * 8;
-  const pending = Math.max(0, totalEarned - processed);
-
-  // Convert new stamps into vouchers
-  const { vouchersEarned, stampsRemainder } = applyStampAccrual(currentStamps, pending);
-
-  const newFree = currentFree + vouchersEarned;
-
-  const { error: updateErr } = await admin
-    .from("profiles")
-    .update({
-      loyalty_stamps: stampsRemainder,
-      free_drinks: newFree,
-    })
-    .eq(pk, userId);
-  if (updateErr) throw updateErr;
-
-  console.log("[ME_STATS]", {
-    totalStamps: totalEarned,
-    pending,
-    vouchersEarned,
-    remainder: stampsRemainder,
-    freebiesLeft: newFree,
-  });
+  if (error) throw error;
 
   return {
-    loyaltyStamps: stampsRemainder,
-    vouchers: newFree,
+    loyaltyStamps: Number(data?.loyalty_stamps ?? 0),
+    vouchers: Number(data?.free_drinks ?? 0),
   };
 }

--- a/supabase/functions/me-stats/index.ts
+++ b/supabase/functions/me-stats/index.ts
@@ -1,5 +1,4 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { normalizeRewards } from '../_shared/rewards.ts';
 
 Deno.serve(async (req) => {
   try {
@@ -23,7 +22,30 @@ Deno.serve(async (req) => {
     const userId = auth.user.id;
 
     const db = createClient(url, service, { auth: { persistSession: false } });
-    const { loyaltyStamps, vouchers } = await normalizeRewards(db, userId);
+
+    // Determine profiles primary key (id vs user_id)
+    let pk = 'id';
+    const { error: userIdErr } = await db
+      .from('profiles')
+      .select('user_id')
+      .limit(1);
+    if (!userIdErr) {
+      pk = 'user_id';
+    } else {
+      const { error: idErr } = await db.from('profiles').select('id').limit(1);
+      if (idErr) throw idErr;
+    }
+
+    // Fetch current rewards from profile
+    const { data: profile, error: profileErr } = await db
+      .from('profiles')
+      .select('loyalty_stamps, free_drinks')
+      .eq(pk, userId)
+      .single();
+    if (profileErr) throw profileErr;
+
+    const loyaltyStamps = Number(profile?.loyalty_stamps ?? 0);
+    const vouchers = Number(profile?.free_drinks ?? 0);
 
     return new Response(JSON.stringify({ loyaltyStamps, vouchers }), {
       headers: { 'content-type': 'application/json' },

--- a/supabase/functions/vouchers-sync/index.ts
+++ b/supabase/functions/vouchers-sync/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { normalizeRewards } from "../_shared/rewards.ts";
+import { getProfileRewards } from "../_shared/rewards.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
@@ -23,7 +23,7 @@ serve(async (req: Request) => {
   const { data: { user } } = await auth.auth.getUser();
   if (!user) return new Response("Unauthorized", { status: 401, headers: cors() });
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
-  const stats = await normalizeRewards(admin, user.id);
+  const stats = await getProfileRewards(admin, user.id);
 
   return new Response(
     JSON.stringify({ vouchers: stats.vouchers }),


### PR DESCRIPTION
## Summary
- read loyalty and free-drink counts directly in `me-stats`
- replace `normalizeRewards` helper with lightweight `getProfileRewards`
- update `vouchers-sync` to use the new helper

## Testing
- `npm test`
- `npx supabase functions deploy me-stats` *(fails: Access token not provided)*
- `npx supabase functions deploy vouchers-sync` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b796ed1083229f32e35f0076f043