### PR TITLE
refactor cms content loading to new functions

### DIFF
--- a/src/services/cms.js
+++ b/src/services/cms.js
@@ -3,10 +3,30 @@ import { markLoaded } from '../boot/loadingSignals';
 
 const extra = (Constants?.expoConfig?.extra) || (Constants?.manifest?.extra) || {};
 
+// Read anon key / functions URL from localStorage with env fallbacks
+function getLocal(key) {
+  try {
+    return globalThis?.localStorage?.getItem?.(key) || '';
+  } catch {
+    return '';
+  }
+}
+
+const anonKey = getLocal('cmsAnon') || extra.CMS_ANON || '';
+const functionsBase = getLocal('cmsFunctionsUrl') ||
+  extra.CMS_FUNCTIONS_URL ||
+  'https://eamewialuovzguldcdcf.functions.supabase.co';
+
 // Normalised config so future code can rely on CMS_CONFIG.*
 const CMS_CONFIG = {
-  functionsBase: extra.CMS_FUNCTIONS_URL || 'https://eamewialuovzguldcdcf.functions.supabase.co',
-  anonKey: extra.CMS_ANON || ''
+  functionsBase,
+  anonKey,
+  api: {
+    list: `${functionsBase}/cms-list`,
+    get: `${functionsBase}/cms-get`,
+    set: `${functionsBase}/cms-set`,
+    del: `${functionsBase}/cms-del`,
+  }
 };
 
 // honour disableFallback=false – if network fails, return cached data
@@ -14,39 +34,31 @@ const disableFallback = false;
 
 let cached = globalThis.preloaded?.cms || null;
 
+// Helper to fetch all keys then each value
+async function fetchAllCmsKeys(cfg) {
+  const headers = cfg.anonKey
+    ? { Authorization: `Bearer ${cfg.anonKey}`, apikey: cfg.anonKey }
+    : {};
+  const listRes = await fetch(`${cfg.api.list}?like=%25`, { headers });
+  const { keys = [] } = await listRes.json().catch(() => ({}));
+  const entries = await Promise.all(keys.map(async (key) => {
+    const r = await fetch(`${cfg.api.get}?key=${encodeURIComponent(key)}`, { headers });
+    const j = await r.json().catch(() => ({}));
+    return [key, j.value ?? j.data ?? ''];
+  }));
+  return Object.fromEntries(entries);
+}
+
 // Fetch all CMS keys by listing then retrieving each value individually
 export async function getCMS(force = false) {
   if (!force && cached) return cached;
-  const headers = CMS_CONFIG.anonKey
-    ? { Authorization: `Bearer ${CMS_CONFIG.anonKey}`, apikey: CMS_CONFIG.anonKey }
-    : {};
+  if (!CMS_CONFIG.functionsBase || !CMS_CONFIG.anonKey) {
+    console.warn('[CMS] missing Supabase function URL or anon key');
+    markLoaded('cms');
+    return {};
+  }
   try {
-    // First list all keys
-    const listRes = await fetch(`${CMS_CONFIG.functionsBase}/cms-list?like=%25`, { headers });
-    if (!listRes.ok) throw new Error('list failed');
-    const listPayload = await listRes.json();
-    const keys = Array.isArray(listPayload?.data)
-      ? listPayload.data
-      : Array.isArray(listPayload)
-        ? listPayload
-        : [];
-
-    const out = {};
-    for (const k of keys) {
-      const key = typeof k === 'string' ? k : k?.key || k?.name;
-      if (!key) continue;
-      const res = await fetch(`${CMS_CONFIG.functionsBase}/cms-get?key=${encodeURIComponent(key)}`, { headers });
-      if (!res.ok) continue;
-      let value;
-      try {
-        const payload = await res.json();
-        value = payload?.value ?? payload?.data ?? payload;
-      } catch {
-        value = await res.text();
-      }
-      out[key] = value;
-    }
-
+    const out = await fetchAllCmsKeys(CMS_CONFIG);
     cached = out;
     globalThis.preloaded = globalThis.preloaded || {};
     globalThis.preloaded.cms = out;


### PR DESCRIPTION
## Summary
- use Supabase cms-texts functions to list and fetch CMS keys
- read anon key and function URL from local storage with fallbacks
- build derived CMS API config and drop old origin spoofing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b996b00b6c83229a8fbf0f44ac7b03