### PR TITLE
Apply membership discount when no free drinks

### DIFF
--- a/__tests__/orders.test.ts
+++ b/__tests__/orders.test.ts
@@ -4,6 +4,7 @@ import { writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { buildOrderRow, normalizeSource } from '../src/services/order-row.js';
+import { calculateOrderTotals } from '../supabase/functions/create-order/calc.js';
 
 test('buildOrderRow includes pickup_code and preserves normalized source_meta', () => {
   const { source, source_meta } = normalizeSource('legacy-web');
@@ -50,4 +51,32 @@ test('saveReceiptForUser logs source app', async () => {
   assert.equal(call?.arguments[1], 'app');
   assert.equal(call?.arguments[3], 'app');
   log.mock.restore();
+});
+
+test('calculateOrderTotals applies membership discount', () => {
+  const { total } = calculateOrderTotals({
+    items: [
+      { sku: 'latte', qty: 2 },
+      { sku: 'tea', qty: 1 },
+    ],
+    syrupShots: 0,
+    payItForward: 0,
+    redeemCount: 0,
+    membershipTier: 'paid',
+    freebies: 0,
+  });
+  // latte 350*2 + tea 250 = 950 -> 10% discount = 95 -> total 855
+  assert.equal(total, 855);
+});
+
+test('calculateOrderTotals skips discount when freebie present', () => {
+  const { total } = calculateOrderTotals({
+    items: [{ sku: 'latte', qty: 1 }],
+    syrupShots: 0,
+    payItForward: 0,
+    redeemCount: 0,
+    membershipTier: 'paid',
+    freebies: 1,
+  });
+  assert.equal(total, 350);
 });

--- a/__tests__/receipt.test.ts
+++ b/__tests__/receipt.test.ts
@@ -67,3 +67,36 @@ test('buildReceipt sets source to app', () => {
   });
   assert.equal(receipt.source, 'app');
 });
+
+test('applies membership discount when no vouchers used', () => {
+  const receipt = buildReceipt({
+    cartItems: [
+      { id: 'coffee:latte', name: 'Latte', quantity: 2, price: 3 },
+      { id: 'bagel', name: 'Bagel', quantity: 1, price: 2 },
+    ],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+    vouchersApplied: 0,
+    discountRate: 0.1,
+    rng: () => 0.5,
+    uuidGenerator: () => 'd1',
+  });
+  // only latte items (drinks) get discount: 2 * 3 * 0.1 = 0.6
+  assert.equal(receipt.totals.discounts, 0.6);
+  assert.equal(receipt.totals.grandTotal, 7.4);
+});
+
+test('membership discount ignored when voucher applied', () => {
+  const receipt = buildReceipt({
+    cartItems: [
+      { id: 'coffee:latte', name: 'Latte', quantity: 1, price: 3 },
+    ],
+    selectedTimeSlot: { start: new Date(0), end: new Date(600000) },
+    vouchersApplied: 1,
+    discountRate: 0.1,
+    rng: () => 0.6,
+    uuidGenerator: () => 'd2',
+  });
+  // voucher covers the drink; membership discount not applied
+  assert.equal(receipt.totals.discounts, 3);
+  assert.equal(receipt.totals.grandTotal, 0);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grant-rewards": "node scripts/grant-rewards.js",
     "reset-rewards": "node scripts/reset-rewards.js",
     "sync-menu-items": "node scripts/sync-menu-items.js",
-    "test": "tsc __tests__/receipt.test.ts __tests__/loyalty.test.ts __tests__/orders.test.ts src/utils/receipt.ts src/utils/loyalty.ts src/services/order-row.ts src/services/orders.ts --module node16 --target ES2020 --outDir build && cp build/src/services/order-row.js build/src/services/order-row && node --test build/__tests__/receipt.test.js build/__tests__/loyalty.test.js build/__tests__/orders.test.js"
+    "test": "tsc __tests__/receipt.test.ts __tests__/loyalty.test.ts __tests__/orders.test.ts src/utils/receipt.ts src/utils/loyalty.ts src/services/order-row.ts src/services/orders.ts supabase/functions/create-order/calc.ts --module node16 --target ES2020 --outDir build && cp build/src/services/order-row.js build/src/services/order-row && cp src/utils/isDrinkItem.js build/src/utils/isDrinkItem.js && node --test build/__tests__/receipt.test.js build/__tests__/loyalty.test.js build/__tests__/orders.test.js"
   },
   "dependencies": {
     "@expo-google-fonts/fraunces": "^0.4.0",

--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -18,13 +18,36 @@ import { checkoutLoyalty } from '../services/loyalty';
 
 export default function CartScreen({ navigation }) {
   const insets = useSafeAreaInsets();
-  const { stats = { vouchers: 0 }, refreshStats, setStats } =
+  const { stats = { vouchers: 0, freebiesLeft: 0 }, refreshStats, setStats } =
     useContext(StatsContext) || {
-      stats: { vouchers: 0 },
+      stats: { vouchers: 0, freebiesLeft: 0 },
       refreshStats: async () => {},
       setStats: () => {},
     };
   const freeDrinks = Number(stats?.vouchers ?? 0);
+  const freebiesLeft = Number(stats?.freebiesLeft ?? 0);
+
+  const [membershipTier, setMembershipTier] = useState('free');
+  useEffect(() => {
+    (async () => {
+      try {
+        const m = await getMembershipSummary();
+        setMembershipTier(m?.tier || 'free');
+      } catch {}
+    })();
+  }, []);
+
+  const membershipDiscountRate =
+    membershipTier === 'paid' && freebiesLeft === 0 ? 0.1 : 0;
+  const membershipDiscount = useMemo(() => {
+    if (membershipDiscountRate <= 0) return 0;
+    return items
+      .filter(isDrinkItem)
+      .reduce(
+        (sum, it) => sum + (it.price || 0) * (it.quantity || 0) * membershipDiscountRate,
+        0,
+      );
+  }, [items, membershipDiscountRate]);
   const { setHasOrders, refreshOrdersPresence } = useOrdersPresence();
 
   const showToast = (msg) => {
@@ -229,6 +252,13 @@ export default function CartScreen({ navigation }) {
           <Text style={styles.subtotalValue}>{formatCurrency(subtotal)}</Text>
         </View>
 
+        {membershipDiscountRate > 0 && membershipDiscount > 0 && (
+          <View style={styles.footerTopRow}>
+            <Text style={styles.subtotalLabel}>Membership discount</Text>
+            <Text style={styles.subtotalValue}>- {formatCurrency(membershipDiscount)}</Text>
+          </View>
+        )}
+
         <View style={styles.voucherPanel}>
           <Text style={styles.voucherText}>Free drinks available: {freeDrinks}</Text>
           <View style={styles.voucherRow}>
@@ -273,6 +303,7 @@ export default function CartScreen({ navigation }) {
                 customer: null,
                 pifContribution: 0,
                 vouchersApplied: redeemCount,
+                discountRate: membershipDiscountRate,
                 paymentMethod: 'test',
               });
 

--- a/src/utils/receipt.ts
+++ b/src/utils/receipt.ts
@@ -1,5 +1,6 @@
 
 import formatCurrency from './formatCurrency.js';
+import { isDrinkItem } from './isDrinkItem.js';
 
 export type ReceiptItemModifier =
   | { type: 'altMilk'; label: string; priceDelta: number }
@@ -58,6 +59,7 @@ export function buildReceipt({
   customer,
   pifContribution = 0,
   vouchersApplied = 0,
+  discountRate = 0,
   paymentMethod = 'test',
   rng = Math.random,
   uuidGenerator = () => (globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : Math.random().toString(36).slice(2)),
@@ -79,6 +81,7 @@ export function buildReceipt({
   customer?: { id?: string; email?: string } | null;
   pifContribution?: number;
   vouchersApplied?: number;
+  discountRate?: number;
   paymentMethod?: 'apple_pay' | 'card' | 'cash' | 'test';
   rng?: () => number;
   uuidGenerator?: () => string;
@@ -129,7 +132,15 @@ export function buildReceipt({
     discounts += redeem * item.unitBasePrice;
     vouchersLeft -= redeem;
   }
-  discounts = round2(discounts);
+  let membershipDiscount = 0;
+  if (vouchersApplied === 0 && discountRate > 0) {
+    for (const item of items) {
+      if (isDrinkItem(item)) {
+        membershipDiscount += item.unitBasePrice * item.quantity * discountRate;
+      }
+    }
+  }
+  discounts = round2(discounts + membershipDiscount);
   const tax = 0;
   const pif = round2(pifContribution);
   const grandTotal = round2(subtotal - discounts + pif + tax);

--- a/supabase/functions/create-order/calc.ts
+++ b/supabase/functions/create-order/calc.ts
@@ -1,0 +1,56 @@
+export type MenuItem = { price: number; hot: boolean };
+
+export const MENU: Record<string, MenuItem> = {
+  latte: { price: 350, hot: true },
+  cappuccino: { price: 350, hot: true },
+  americano: { price: 300, hot: true },
+  tea: { price: 250, hot: true },
+  iced_latte: { price: 400, hot: false },
+};
+
+export const SYRUP_PRICE = 50;
+export const PIF_PRICE = 300;
+export const VOUCHER_VALUE = 300;
+
+export function calculateOrderTotals({
+  items,
+  syrupShots,
+  payItForward,
+  redeemCount,
+  membershipTier,
+  freebies,
+}: {
+  items: Array<{ sku: string; qty: number }>;
+  syrupShots: number;
+  payItForward: number;
+  redeemCount: number;
+  membershipTier: string;
+  freebies: number;
+}): { total: number; hotCount: number } {
+  let total = 0;
+  let hotCount = 0;
+  let drinkSubtotal = 0;
+  for (const it of items) {
+    const sku = String(it?.sku || "");
+    const qty = Number(it?.qty) || 0;
+    const def = MENU[sku];
+    if (!def) throw new Error(`invalid item ${sku}`);
+    const amount = def.price * qty;
+    total += amount;
+    drinkSubtotal += amount;
+    if (def.hot) hotCount += qty;
+  }
+
+  total += SYRUP_PRICE * syrupShots;
+  total += PIF_PRICE * payItForward;
+
+  total -= VOUCHER_VALUE * redeemCount;
+
+  if (membershipTier === "paid" && freebies === 0 && redeemCount === 0) {
+    const discount = Math.round(drinkSubtotal * 0.1);
+    total -= discount;
+  }
+
+  if (total < 0) total = 0;
+  return { total, hotCount };
+}

--- a/supabase/functions/create-order/index.ts
+++ b/supabase/functions/create-order/index.ts
@@ -1,22 +1,16 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  MENU,
+  SYRUP_PRICE,
+  PIF_PRICE,
+  VOUCHER_VALUE,
+  calculateOrderTotals,
+} from "./calc.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-
-type MenuItem = { price: number; hot: boolean };
-const MENU: Record<string, MenuItem> = {
-  latte: { price: 350, hot: true },
-  cappuccino: { price: 350, hot: true },
-  americano: { price: 300, hot: true },
-  tea: { price: 250, hot: true },
-  iced_latte: { price: 400, hot: false },
-};
-
-const SYRUP_PRICE = 50;
-const PIF_PRICE = 300;
-const VOUCHER_VALUE = 300;
 
 function cors() {
   return {
@@ -45,26 +39,36 @@ serve(async (req) => {
   const redeemCount = voucherCodes.length;
   const timeslot = typeof body.timeslot === "string" ? body.timeslot : null;
 
-  let total = 0;
-  let hotCount = 0;
-  for (const it of items) {
-    const sku = String(it?.sku || "");
-    const qty = Number(it?.qty) || 0;
-    const def = MENU[sku];
-    if (!def) {
-      return new Response(JSON.stringify({ error: `invalid item ${sku}` }), { status: 400, headers: { ...cors(), "content-type": "application/json" } });
-    }
-    total += def.price * qty;
-    if (def.hot) hotCount += qty;
-  }
-
-  total += SYRUP_PRICE * syrupShots;
-  total += PIF_PRICE * payItForward;
-
-  total -= VOUCHER_VALUE * redeemCount;
-  if (total < 0) total = 0;
-
   const admin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
+
+  const { data: membership } = await admin
+    .from("memberships")
+    .select("status")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("free_drinks")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const membershipTier = membership?.status === "active" ? "paid" : "free";
+  const freebies = Number(profile?.free_drinks ?? 0);
+
+  let total: number;
+  let hotCount: number;
+  try {
+    ({ total, hotCount } = calculateOrderTotals({
+      items,
+      syrupShots,
+      payItForward,
+      redeemCount,
+      membershipTier,
+      freebies,
+    }));
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return new Response(JSON.stringify({ error: msg }), { status: 400, headers: { ...cors(), "content-type": "application/json" } });
+  }
 
   let pickup_code = "";
   while (true) {


### PR DESCRIPTION
## Summary
- add discountRate option to receipt builder and apply membership discount when vouchers aren't used
- compute paid membership discount in CartScreen and show the savings in the footer
- mirror membership discount on the server create-order function with shared calculator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf42d585a48322aeee05f3cec194a6