### PR TITLE
Guard CartScreen item filtering against undefined arrays

### DIFF
--- a/src/screens/CartScreen.js
+++ b/src/screens/CartScreen.js
@@ -47,6 +47,8 @@ export default function CartScreen({ navigation }) {
     ? cartValue.entries
     : [];
 
+  const safeItems = Array.isArray(items) ? items : [];
+
   const [membershipTier, setMembershipTier] = useState('free');
   useEffect(() => {
     (async () => {
@@ -61,7 +63,7 @@ export default function CartScreen({ navigation }) {
     membershipTier === 'paid' && freebiesLeft === 0 ? 0.1 : 0;
   const membershipDiscount = useMemo(() => {
     if (membershipDiscountRate <= 0) return 0;
-    return items
+    return safeItems
       .filter(isDrinkItem)
       .reduce(
         (sum, it) => sum + (it.price || 0) * (it.quantity || 0) * membershipDiscountRate,
@@ -81,7 +83,7 @@ export default function CartScreen({ navigation }) {
   const tabBarHeight = useTabBarHeight();
 
   const drinkCount = useMemo(
-    () => items.filter(isDrinkItem).reduce((sum, it) => sum + (it.quantity || 0), 0),
+    () => safeItems.filter(isDrinkItem).reduce((sum, it) => sum + (it.quantity || 0), 0),
     [items]
   );
   const maxRedeemable = Math.min(drinkCount, freeDrinks);


### PR DESCRIPTION
## Summary
- Add `safeItems` helper in CartScreen to avoid `.filter` on non-array values
- Use `safeItems` for membership discount and drink count calculations

## Testing
- `npm test` *(fails: The requested module '../lib/supabase.js' does not provide an export named 'hasSupabase')*

------
https://chatgpt.com/codex/tasks/task_e_68bfc6a50d5483229fba544a93745969