### PR TITLE
Add CMS delete support and Square sync propagation

### DIFF
--- a/src/cms/cmsClient.ts
+++ b/src/cms/cmsClient.ts
@@ -1,8 +1,28 @@
 const FNS  = 'https://eamewialuovzguldcdcf.functions.supabase.co';
 const ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVhbWV3aWFsdW92emd1bGRjZGNmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxNjY5MjIsImV4cCI6MjA3MDc0MjkyMn0.oZy-UH7mB7NSFZZyivm3dbCtjsbOahcD2_coUNiiQNs';
 
+const env =
+  typeof process !== 'undefined' && process?.env
+    ? (process.env as Record<string, string | undefined>)
+    : {};
+
+const CMS_WRITE_SECRET =
+  env.EXPO_PUBLIC_CMS_WRITE_SECRET ||
+  env.CMS_WRITE_SECRET ||
+  '';
+
 function h(extra: Record<string,string> = {}) {
   return { Authorization: `Bearer ${ANON}`, apikey: ANON, ...extra };
+}
+
+function withCmsSecret(extra: Record<string, string> = {}) {
+  if (CMS_WRITE_SECRET) {
+    return h({ ...extra, 'x-cms-secret': CMS_WRITE_SECRET });
+  }
+  if (typeof console !== 'undefined') {
+    console.warn('[CMS] CMS_WRITE_SECRET is not set; delete operations may fail.');
+  }
+  return h(extra);
 }
 
 export async function listKeys(like = '%'): Promise<string[]> {
@@ -41,7 +61,7 @@ export async function fetchCMSMap(): Promise<Record<string,string>> {
 
 export async function deleteKey(key: string): Promise<boolean> {
   const url = `${FNS}/cms-del?key=${encodeURIComponent(key)}`;
-  const res = await fetch(url, { method: 'DELETE', headers: h() });
+  const res = await fetch(url, { method: 'DELETE', headers: withCmsSecret() });
   console.log('[CMS] delete', key, '→', res.status);
   return res.ok;
 }

--- a/src/cms/cmsClient.ts
+++ b/src/cms/cmsClient.ts
@@ -38,3 +38,10 @@ export async function fetchCMSMap(): Promise<Record<string,string>> {
   for (const [k, v] of pairs) if (v != null) out[k] = v;
   return out;
 }
+
+export async function deleteKey(key: string): Promise<boolean> {
+  const url = `${FNS}/cms-del?key=${encodeURIComponent(key)}`;
+  const res = await fetch(url, { method: 'DELETE', headers: h() });
+  console.log('[CMS] delete', key, '→', res.status);
+  return res.ok;
+}

--- a/supabase/functions/cms-del/index.ts
+++ b/supabase/functions/cms-del/index.ts
@@ -1,0 +1,66 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("CMS_SUPABASE_URL")!;
+const SERVICE = Deno.env.get("CMS_SERVICE_ROLE")!;
+const CMS_WRITE_SECRET = Deno.env.get("CMS_WRITE_SECRET")!;
+const FUNCTIONS_BASE = SUPABASE_URL.replace(".supabase.co", ".functions.supabase.co");
+
+const cors = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-headers": "authorization, x-client-info, apikey, content-type, x-cms-secret",
+  "access-control-allow-methods": "GET, POST, OPTIONS, DELETE",
+};
+
+function json(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json", ...cors, ...(init.headers || {}) },
+    status: init.status,
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
+
+  try {
+    if (req.method !== "DELETE") {
+      return json({ error: "method_not_allowed" }, { status: 405 });
+    }
+
+    const secret = req.headers.get("x-cms-secret") || "";
+    if (secret !== CMS_WRITE_SECRET) {
+      return json({ error: "unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const rawKey = searchParams.get("key") || "";
+    const key = rawKey.replace(/\/+$/, "");
+    if (!key) throw new Error("Missing key");
+
+    const supabase = createClient(SUPABASE_URL, SERVICE);
+    const { error } = await supabase.from("cms_texts").delete().eq("key", key);
+    if (error) throw error;
+
+    const posSyncResponse = await fetch(`${FUNCTIONS_BASE}/pos-sync`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${SERVICE}`,
+        apikey: SERVICE,
+      },
+      body: JSON.stringify({ action: "cms-delete", key }),
+    });
+
+    if (!posSyncResponse.ok) {
+      const text = await posSyncResponse.text();
+      throw new Error(`pos-sync failed: ${posSyncResponse.status} ${text}`);
+    }
+
+    return json({ ok: true });
+  } catch (e) {
+    console.error("[cms-del]", e);
+    const message = e instanceof Error ? e.message : String(e);
+    const status = message === "Missing key" ? 400 : 500;
+    return json({ error: message }, { status });
+  }
+});


### PR DESCRIPTION
## Summary
- add a cms client helper for issuing DELETE calls against the cms-del function
- implement a new cms-del Supabase function that enforces secrets, removes cms_texts rows, and notifies pos-sync so Square catalog stays in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d27e6690808322b0d2cf47713d5607